### PR TITLE
img-51 - (see Appendix A of MIL-STD-2500C). The NITF parser currently…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,4 @@ hs_err_pid*
 
 # ignore intellij files
 *.iml
-
 .idea/

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,8 +43,8 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
             </plugins>
@@ -72,21 +72,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.12.1</version>
+                <version>2.15</version>
                 <executions>
                     <execution>
-                    <id>validate</id>
-                    <phase>validate</phase>
-                    <configuration>
-                        <configLocation>file:${project.parent.basedir}/checkstyle.xml</configLocation>
-                        <encoding>UTF-8</encoding>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                        <linkXRef>false</linkXRef>
-                    </configuration>
-                    <goals>
-                        <goal>check</goal>
-                    </goals>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <configLocation>${project.parent.basedir}/checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <linkXRef>false</linkXRef>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -142,19 +142,66 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.5.8.201207111220</version>
+                <version>0.7.4.201502262128</version>
                 <executions>
                     <execution>
+                        <id>default-prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>report</id>
-                        <phase>test</phase>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.directory}/site/project-info/jacoco/
+                            </outputDirectory>
+                        </configuration>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <!--
+                                    When overriding the limits in child pom files make sure
+                                    to override all four limits. Limits that are excluded
+                                    will be set to 0 not 0.75
+                                    -->
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.74</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -196,6 +243,5 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageCoordinatePoint.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageCoordinatePoint.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+
+package org.codice.imaging.nitf.core;
+
+/**
+ * A parent class for the coordinate point types (Decimal Degrees, MGRS, UTM, Geo).
+ */
+public abstract class ImageCoordinatePoint {
+
+    /**
+     * the string as originally supplied to a subclass.
+     */
+    protected String sourceString;
+
+    /**
+     Return the original source format.
+
+     @return the original source format.
+     */
+    public final String getSourceFormat() {
+        return sourceString;
+    }
+
+    /**
+     *
+     * @return the ImageCoordinatesRepresentation that correlates to the subclass type.
+     */
+    public abstract ImageCoordinatesRepresentation getImageCoordinatesRepresentation();
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageCoordinates.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageCoordinates.java
@@ -16,13 +16,14 @@ package org.codice.imaging.nitf.core;
 
 /**
     Coordinates of an image.
+    @param <T> - the type of coordinate representation contained in this ImageCoordinates
 */
-public class ImageCoordinates {
+public class ImageCoordinates<T extends ImageCoordinatePoint> {
 
-    private ImageCoordinatePair coordinate00;
-    private ImageCoordinatePair coordinate0MaxCol;
-    private ImageCoordinatePair coordinateMaxRowMaxCol;
-    private ImageCoordinatePair coordinateMaxRow0;
+    private T coordinate00;
+    private T coordinate0MaxCol;
+    private T coordinateMaxRowMaxCol;
+    private T coordinateMaxRow0;
 
     private static final int COORDINATE00_INDEX = 0;
     private static final int COORDINATE0MAXCOL_INDEX = 1;
@@ -32,9 +33,9 @@ public class ImageCoordinates {
     /**
         Constructor.
 
-        @param coord array of four coordinate pairs, in the order [0,0], [0, MaxCol], [MaxRow, MaxCol], [MaxRow, 0].
+        @param coord array of four coordinates of type &lt;T&gt;, in the order [0,0], [0, MaxCol], [MaxRow, MaxCol], [MaxRow, 0].
     */
-    public ImageCoordinates(final ImageCoordinatePair[] coord) {
+    public ImageCoordinates(final T[] coord) {
         coordinate00 = coord[COORDINATE00_INDEX];
         coordinate0MaxCol = coord[COORDINATE0MAXCOL_INDEX];
         coordinateMaxRowMaxCol = coord[COORDINATEMAXROWMAXCOL_INDEX];
@@ -42,38 +43,38 @@ public class ImageCoordinates {
     }
 
     /**
-        Get the coordinate pair for [0,0].
+        Get the coordinate of type &lt;T&gt; for [0,0].
 
-        @return corresponding coordinate pair.
+        @return corresponding coordinate.
     */
-    public final ImageCoordinatePair getCoordinate00() {
+    public final T getCoordinate00() {
         return coordinate00;
     }
 
     /**
-        Get the coordinate pair for [0,MaxCol].
+        Get the coordinate of type &lt;T&gt; for [0,MaxCol].
 
-        @return corresponding coordinate pair.
+        @return corresponding coordinate.
     */
-    public final ImageCoordinatePair getCoordinate0MaxCol() {
+    public final T getCoordinate0MaxCol() {
         return coordinate0MaxCol;
     }
 
     /**
-        Get the coordinate pair for [MaxRow,MaxCol].
+        Get the coordinate of type &lt;T&gt; for [MaxRow,MaxCol].
 
-        @return corresponding coordinate pair.
+        @return corresponding coordinate.
     */
-    public final ImageCoordinatePair getCoordinateMaxRowMaxCol() {
+    public final T getCoordinateMaxRowMaxCol() {
         return coordinateMaxRowMaxCol;
     }
 
     /**
-        Get the coordinate pair for [MaxRow,0].
+        Get the coordinate of type &lt;T&gt; for [MaxRow,0].
 
-        @return corresponding coordinate pair.
+        @return corresponding coordinate.
     */
-    public final ImageCoordinatePair getCoordinateMaxRow0() {
+    public final T getCoordinateMaxRow0() {
         return coordinateMaxRow0;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageDecimalDegreesCoordinatePair.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageDecimalDegreesCoordinatePair.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import static org.codice.imaging.nitf.core.NitfConstants.LAT_DECIMAL_DEGREES_FORMAT_LENGTH;
+import static org.codice.imaging.nitf.core.NitfConstants.MINUTES_IN_ONE_DEGREE;
+import static org.codice.imaging.nitf.core.NitfConstants.SECONDS_IN_ONE_MINUTE;
+
+import java.text.ParseException;
+/**
+    A coordinate pair (latitude / longitude or equivalent).
+*/
+public class ImageDecimalDegreesCoordinatePair extends ImageCoordinatePoint {
+
+    private double lat = 0.0;
+    private double lon = 0.0;
+
+    /**
+        Default constructor.
+    */
+    public ImageDecimalDegreesCoordinatePair() {
+        super();
+    }
+
+    /**
+        Constructor from a latitude / longitude pair.
+
+        @param latitude the latitude value (positive for North).
+        @param longitude the longitude value (positive for East).
+    */
+    public ImageDecimalDegreesCoordinatePair(final double latitude, final double longitude) {
+        lat = latitude;
+        lon = longitude;
+    }
+
+    /**
+        Return the latitude value.
+        <p>
+        North is positive.
+
+        @return the latitude value.
+    */
+    public final double getLatitude() {
+        return lat;
+    }
+
+    /**
+        Return the longitude value.
+        <p>
+        East is positive.
+
+        @return the longitude value.
+    */
+    public final double getLongitude() {
+        return lon;
+    }
+
+    private double buildDecimalDegrees(final String degStr, final String minStr, final String secStr) {
+        int degrees = Integer.parseInt(degStr);
+        int minutes = Integer.parseInt(minStr);
+        int seconds = Integer.parseInt(secStr);
+        return degrees + ((minutes + (seconds / SECONDS_IN_ONE_MINUTE)) / MINUTES_IN_ONE_DEGREE);
+    }
+
+    /**
+        Set latitude and longitude from Decimal Degrees string.
+
+        @param dd string representation in MIL-STD-2500C ±dd.ddd±ddd.ddd form
+        @throws ParseException if the format is not as expected.
+     */
+    public final void setFromDecimalDegrees(final String dd) throws ParseException {
+        if (dd == null) {
+            throw new ParseException("Null argument for decimal degrees parsing", 0);
+        }
+
+        if (dd.length() != "+dd.ddd+ddd.ddd".length()) {
+            throw new ParseException("Incorrect length for decimal degrees parsing", 0);
+        }
+
+        sourceString = dd;
+        String latPart = dd.substring(0, LAT_DECIMAL_DEGREES_FORMAT_LENGTH);
+        String lonPart = dd.substring(LAT_DECIMAL_DEGREES_FORMAT_LENGTH);
+        try {
+            lat = Double.parseDouble(latPart);
+            lon = Double.parseDouble(lonPart);
+        } catch (NumberFormatException ex) {
+            throw new ParseException(String.format("Incorrect decimal degrees format: %s", dd), 0);
+        }
+    }
+
+    @Override
+    public final ImageCoordinatesRepresentation getImageCoordinatesRepresentation() {
+        return ImageCoordinatesRepresentation.DECIMALDEGREES;
+    }
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageGeographicCoordinatePair.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageGeographicCoordinatePair.java
@@ -19,16 +19,16 @@ import java.text.ParseException;
 /**
     A coordinate pair (latitude / longitude or equivalent).
 */
-public class ImageCoordinatePair {
+public class ImageGeographicCoordinatePair extends ImageCoordinatePoint {
 
     private double lat = 0.0;
     private double lon = 0.0;
-    private String sourceString = null;
 
     /**
         Default constructor.
     */
-    public ImageCoordinatePair() {
+    public ImageGeographicCoordinatePair() {
+        super();
     }
 
     /**
@@ -37,7 +37,7 @@ public class ImageCoordinatePair {
         @param latitude the latitude value (positive for North).
         @param longitude the longitude value (positive for East).
     */
-    public ImageCoordinatePair(final double latitude, final double longitude) {
+    public ImageGeographicCoordinatePair(final double latitude, final double longitude) {
         lat = latitude;
         lon = longitude;
     }
@@ -70,9 +70,9 @@ public class ImageCoordinatePair {
         @param dms string representation in MIL-STD-2500C ddmmssXdddmmssY form
         @throws ParseException if the format is not as expected.
      */
-    public final void setFromDMS(final String dms) throws ParseException {
+    public final void setFromGeographicCoordinates(final String dms) throws ParseException {
         sourceString = dms;
-        checkDMSparameterIsProbablyValid(dms);
+        checkGeographicCoordinateParameterIsProbablyValid(dms);
         String latDegrees = dms.substring(NitfConstants.LAT_DEGREES_OFFSET, NitfConstants.LAT_DEGREES_LENGTH);
         String latMinutes = dms.substring(NitfConstants.LAT_MINUTES_OFFSET, NitfConstants.LAT_MINUTES_OFFSET + NitfConstants.MINUTES_LENGTH);
         String latSeconds = dms.substring(NitfConstants.LAT_SECONDS_OFFSET, NitfConstants.LAT_SECONDS_OFFSET + NitfConstants.SECONDS_LENGTH);
@@ -93,10 +93,11 @@ public class ImageCoordinatePair {
         }
     }
 
-    private void checkDMSparameterIsProbablyValid(final String dms) throws ParseException {
+    private void checkGeographicCoordinateParameterIsProbablyValid(final String dms) throws ParseException {
         if (dms == null) {
             throw new ParseException("Null argument for DMS parsing", 0);
         }
+
         if (dms.length() != "ddmmssXdddmmssY".length()) {
             throw new ParseException("Incorrect length for DMS parsing:" + dms.length(), 0);
         }
@@ -136,61 +137,8 @@ public class ImageCoordinatePair {
         return degrees + ((minutes + (seconds / NitfConstants.SECONDS_IN_ONE_MINUTE)) / NitfConstants.MINUTES_IN_ONE_DEGREE);
     }
 
-    /**
-        Set the value from UTM / UPS North.
-        <p>
-        This format will not be converted to degrees, so getLatitude and getLongitude() will return
-        default (0) values.
-
-        @param utm the string representation of the coordinates.
-        @throws ParseException if the string does not have the correct length / format.
-    */
-    public final void setFromUTMUPSNorth(final String utm) throws ParseException {
-        if (utm.length() != "zzeeeeeennnnnnn".length()) {
-            throw new ParseException("Incorrect length for UTM / UPS North String", 0);
-        }
-        sourceString = utm;
-    }
-
-    /**
-        Set latitude and longitude from Decimal Degrees string.
-
-        @param dd string representation in MIL-STD-2500C ±dd.ddd±ddd.ddd form
-        @throws ParseException if the format is not as expected.
-     */
-    public final void setFromDecimalDegrees(final String dd) throws ParseException {
-        if (dd.length() != "+dd.ddd+ddd.ddd".length()) {
-            throw new ParseException("Incorrect length for decimal degrees parsing", 0);
-        }
-        sourceString = dd;
-        String latPart = dd.substring(0, NitfConstants.LAT_DECIMAL_DEGREES_FORMAT_LENGTH);
-        String lonPart = dd.substring(NitfConstants.LAT_DECIMAL_DEGREES_FORMAT_LENGTH);
-        try {
-            lat = Double.parseDouble(latPart);
-            lon = Double.parseDouble(lonPart);
-        } catch (NumberFormatException ex) {
-            throw new ParseException(String.format("Incorrect decimal degrees format: %s", dd), 0);
-        }
-    }
-
-    /**
-        Return the original source format.
-
-        @return the original source format.
-    */
-    public final String getSourceFormat() {
-        return sourceString;
-    }
-
-    /**
-        Set the value from MGRS.
-        <p>
-        This format will not be converted to degrees, so getLatitude and getLongitude() will return
-        default (0) values.
-
-        @param mgrs the string representation of the coordinates.
-    */
-    final void setFromMGRS(final String mgrs) {
-        sourceString = mgrs;
+    @Override
+    public final ImageCoordinatesRepresentation getImageCoordinatesRepresentation() {
+        return ImageCoordinatesRepresentation.GEOGRAPHIC;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageMgrsCoordinate.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageMgrsCoordinate.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import java.text.ParseException;
+
+/**
+ * A coordinate in MGRS format (zzBJKeeeeennnnn) where:
+ *  'zz' is the zone,
+ *  'B' is the band within the zone
+ *  'JK' is the 100km grid
+ *  'eeeee' is the easting value
+ *  'nnnnn' is the northing value.
+ */
+public class ImageMgrsCoordinate extends ImageCoordinatePoint {
+    private static final int ZONE_FIELD_START = 0;
+
+    private static final int ZONE_FIELD_END = 2;
+
+    private static final int BAND_FIELD_START = ZONE_FIELD_END;
+
+    private static final int BAND_FIELD_END = 3;
+
+    private static final int GRID_FIELD_START = BAND_FIELD_END;
+
+    private static final int GRID_FIELD_END = 5;
+
+    private static final int EASTING_FIELD_START = GRID_FIELD_END;
+
+    private static final int EASTING_FIELD_END = 10;
+
+    private static final int NORTHING_FIELD_START = EASTING_FIELD_END;
+
+    private Integer zone;
+
+    private Integer easting;
+
+    private Integer northing;
+
+    private String grid;
+
+    private String band;
+
+    /**
+     * Default constructor.
+     */
+    public ImageMgrsCoordinate() {
+        super();
+    }
+
+    /**
+     * Set the value from MGRS.
+     * <p>
+     * This format will not be converted to degrees.  The values supplied by the input
+     * are captured here and returned as they were read.
+     *
+     * @param mgrs the string representation of the coordinates.
+     */
+    final void setFromMgrs(final String mgrs) throws ParseException {
+        if (mgrs == null) {
+            throw new ParseException("Null argument for MGRS parsing", 0);
+        }
+
+        if (mgrs.length() != "zzBJKeeeeennnnn".length()) {
+            throw new ParseException("Incorrect length for MGRS String", 0);
+        }
+
+        this.zone = Integer.valueOf(mgrs.substring(ZONE_FIELD_START, ZONE_FIELD_END).trim());
+        this.band = mgrs.substring(BAND_FIELD_START, BAND_FIELD_END).trim();
+        this.grid = mgrs.substring(GRID_FIELD_START, GRID_FIELD_END).trim();
+        this.easting = Integer.valueOf(mgrs.substring(EASTING_FIELD_START, EASTING_FIELD_END).trim());
+        this.northing = Integer.valueOf(mgrs.substring(NORTHING_FIELD_START).trim());
+
+        super.sourceString = mgrs;
+    }
+
+    /**
+     *
+     * @return the easting value from the source MGRS.
+     */
+    public final Integer getEasting() {
+        return easting;
+    }
+
+    /**
+     *
+     * @return the grid value from the supplied MGRS.
+     */
+    public final String getGrid() {
+        return grid;
+    }
+
+    /**
+     *
+     * @return the northing value from the supplied MGRS.
+     */
+    public final Integer getNorthing() {
+        return northing;
+    }
+
+    /**
+     *
+     * @return the zone value from the supplied MGRS.
+     */
+    public final Integer getZone() {
+        return zone;
+    }
+
+    /**
+     *
+     * @return the band value from the supplied MGRS.
+     */
+    public final String getBand() {
+        return band;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public final ImageCoordinatesRepresentation getImageCoordinatesRepresentation() {
+        return ImageCoordinatesRepresentation.MGRS;
+    }
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/ImageUtmCoordinate.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ImageUtmCoordinate.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import java.text.ParseException;
+
+/**
+ * A coordinate pair (latitude / longitude or equivalent).
+ */
+public class ImageUtmCoordinate extends ImageCoordinatePoint {
+
+    private static final int ZONE_FIELD_LENGTH = 2;
+
+    private static final int EASTING_FIELD_LENGTH = 6;
+
+    private final ImageCoordinatesRepresentation imageCoordinatesRepresentation;
+
+    private Integer zone;
+
+    private Integer easting;
+
+    private Integer northing;
+
+    /**
+     * Default constructor.
+     *
+     * @param coordinatesRepresentation - must be either ImageCoordinateRepresentation.UTMUPSNORTH or ImageCoordinateRepresentation.UTMUPSSOUTH.
+     *                                       may not be null.
+     */
+    public ImageUtmCoordinate(final ImageCoordinatesRepresentation coordinatesRepresentation) {
+        super();
+
+        if (coordinatesRepresentation != ImageCoordinatesRepresentation.UTMUPSNORTH
+                && coordinatesRepresentation != ImageCoordinatesRepresentation.UTMUPSSOUTH) {
+            throw new IllegalArgumentException(
+                    "ImageUtmCoordinate(): constructor argument 'imageCoordinateRepresentation' must be either 'N' or 'S'.");
+        }
+
+        this.imageCoordinatesRepresentation = coordinatesRepresentation;
+    }
+
+    /**
+     * Set the value from UTM / UPS North.
+     * <p>
+     * This format will not be converted to degrees, so getLatitude and getLongitude() will return
+     * default (0) values.
+     *
+     * @param utm the string representation of the coordinates.
+     * @throws ParseException if the string does not have the correct length / format.
+     */
+    public final void setFromUtmUps(final String utm) throws ParseException {
+        if (utm == null) {
+            throw new ParseException("Null argument for UTM parsing", 0);
+        }
+
+        if (utm.length() != "zzeeeeeennnnnnn".length()) {
+            throw new ParseException("Incorrect length for UTM / UPS North String", 0);
+        }
+
+        this.zone = Integer.valueOf(utm.substring(0, ZONE_FIELD_LENGTH).trim());
+        this.easting = Integer
+                .valueOf(utm.substring(2, ZONE_FIELD_LENGTH + EASTING_FIELD_LENGTH).trim());
+        this.northing = Integer
+                .valueOf(utm.substring(ZONE_FIELD_LENGTH + EASTING_FIELD_LENGTH).trim());
+
+        super.sourceString = utm;
+    }
+
+    /**
+     * @return the zone portion of the supplied utm string.
+     */
+    public final Integer getZone() {
+        return this.zone;
+    }
+
+    /**
+     * @return the easting portion of the supplied utm string.
+     */
+    public final Integer getEasting() {
+        return this.easting;
+    }
+
+    /**
+     * @return the northing portion of the supplied utm string.
+     */
+    public final Integer getNorthing() {
+        return this.northing;
+    }
+
+    @Override
+    public final ImageCoordinatesRepresentation getImageCoordinatesRepresentation() {
+        return this.imageCoordinatesRepresentation;
+    }
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/ParserFunction.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/ParserFunction.java
@@ -1,0 +1,20 @@
+package org.codice.imaging.nitf.core;
+
+import java.text.ParseException;
+
+/**
+ * This functional interface accepts a String and returns the type &lt;T&gt;. This allows us to
+ * write lambdas to handle specific parsing cases.
+ * @param <T> - The type that will be returned when apply() is called.
+ */
+
+@FunctionalInterface
+public interface ParserFunction<T> {
+    /**
+     *
+     * @param string - the string to be parsed.
+     * @return - the parsed object of type &lt;T&gt;.
+     * @throws ParseException - when an error is encountered during parsing.
+     */
+    T apply(String string) throws ParseException;
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/RasterProductFormatAttributeParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/RasterProductFormatAttributeParser.java
@@ -109,7 +109,7 @@ public class RasterProductFormatAttributeParser {
 //             System.out.println("\tAreal coverage sequence number:" + offsetRecord.arealCoverageSequenceNumber);
 //             System.out.println("\tattribute record offset:" + offsetRecord.attributeRecordOffset);
             bytes.position(ATTRIBUTE_SECTION_SUBHEADER_LENGTH + offsetRecord.attributeRecordOffset);
-            switch(offsetRecord.attributeId) {
+            switch (offsetRecord.attributeId) {
                 case CURRENCY_DATE_ATTR_ID:
                     attributes.addCurrencyDate(offsetRecord.arealCoverageSequenceNumber, parseRpfCurrencyDate(bytes, offsetRecord));
                     break;

--- a/core/src/test/java/org/codice/imaging/nitf/core/ImageDecimalDegreesCoordinatePairTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/ImageDecimalDegreesCoordinatePairTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.text.ParseException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ImageDecimalDegreesCoordinatePairTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testImageCoordinatePairDefaultConstructor() {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        assertNotNull(coord);
+    }
+
+    @Test
+    public void testImageCoordinatePairAccessors() {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair(-35.3761, 149.1018);
+        assertNotNull(coord);
+        assertEquals(-35.3761, coord.getLatitude(), 0.00001);
+        assertEquals(149.1018, coord.getLongitude(), 0.00001);
+    }
+
+    @Test
+    public void testNullArgumentDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Null argument for decimal degrees parsing");
+        coord.setFromDecimalDegrees(null);
+    }
+
+    @Test
+    public void testValidArgumentDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        coord.setFromDecimalDegrees("-33.302+150.220");
+        assertNotNull(coord);
+        assertEquals(-33.302, coord.getLatitude(), 0.0001);
+        assertEquals(150.22, coord.getLongitude(), 0.0001);
+        assertEquals("-33.302+150.220", coord.getSourceFormat());
+    }
+
+    @Test
+    public void testBadArgumentLengthDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect length for decimal degrees parsing");
+        coord.setFromDecimalDegrees("333019S1502203");
+    }
+
+    @Test
+    public void testBadFirstHemisphereArgumentDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect decimal degrees format: 333019X1502203E");
+        coord.setFromDecimalDegrees("333019X1502203E");
+    }
+
+    @Test
+    public void testBadSecondHemisphereArgumentDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect decimal degrees format: 333019S1502203Y");
+        coord.setFromDecimalDegrees("333019S1502203Y");
+    }
+
+    @Test
+    public void testNumberFormatArgumentDecimalDegrees() throws ParseException {
+        ImageDecimalDegreesCoordinatePair coord = new ImageDecimalDegreesCoordinatePair();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect decimal degrees format: 333019S1502x03E");
+        coord.setFromDecimalDegrees("333019S1502x03E");
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/ImageGeographicCoordinatePairTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/ImageGeographicCoordinatePairTest.java
@@ -23,19 +23,19 @@ import org.junit.rules.ExpectedException;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class ImageCoordinatePairTest {
+public class ImageGeographicCoordinatePairTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testImageCoordinatePairDefaultConstructor() {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         assertNotNull(coord);
     }
 
     @Test
     public void testImageCoordinatePairAccessors() {
-        ImageCoordinatePair coord = new ImageCoordinatePair(-35.3761, 149.1018);
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair(-35.3761, 149.1018);
         assertNotNull(coord);
         assertEquals(-35.3761, coord.getLatitude(), 0.00001);
         assertEquals(149.1018, coord.getLongitude(), 0.00001);
@@ -43,16 +43,16 @@ public class ImageCoordinatePairTest {
 
     @Test
     public void testNullArgumentDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         exception.expect(ParseException.class);
         exception.expectMessage("Null argument for DMS parsing");
-        coord.setFromDMS(null);
+        coord.setFromGeographicCoordinates(null);
     }
 
     @Test
     public void testValidArgumentDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
-        coord.setFromDMS("333019S1502203E");
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
+        coord.setFromGeographicCoordinates("333019S1502203E");
         assertNotNull(coord);
         assertEquals(-33.5052, coord.getLatitude(), 0.0001);
         assertEquals(150.3675, coord.getLongitude(), 0.0001);
@@ -61,33 +61,33 @@ public class ImageCoordinatePairTest {
 
     @Test
     public void testBadArgumentLengthDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         exception.expect(ParseException.class);
         exception.expectMessage("Incorrect length for DMS parsing:14");
-        coord.setFromDMS("333019S1502203");
+        coord.setFromGeographicCoordinates("333019S1502203");
     }
 
     @Test
     public void testBadFirstHemisphereArgumentDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         exception.expect(ParseException.class);
         exception.expectMessage("Incorrect format for N/S flag while DMS parsing: X(333019X1502203E)");
-        coord.setFromDMS("333019X1502203E");
+        coord.setFromGeographicCoordinates("333019X1502203E");
     }
 
     @Test
     public void testBadSecondHemisphereArgumentDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         exception.expect(ParseException.class);
         exception.expectMessage("Incorrect format for E/W flag while DMS parsing: Y(333019S1502203Y)");
-        coord.setFromDMS("333019S1502203Y");
+        coord.setFromGeographicCoordinates("333019S1502203Y");
     }
 
     @Test
     public void testNumberFormatArgumentDMS() throws ParseException {
-        ImageCoordinatePair coord = new ImageCoordinatePair();
+        ImageGeographicCoordinatePair coord = new ImageGeographicCoordinatePair();
         exception.expect(ParseException.class);
         exception.expectMessage("Incorrect DMS format: 333019S1502x03E");
-        coord.setFromDMS("333019S1502x03E");
+        coord.setFromGeographicCoordinates("333019S1502x03E");
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/ImageMgrsCoordinateTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/ImageMgrsCoordinateTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.text.ParseException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ImageMgrsCoordinateTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testImageCoordinatePairDefaultConstructor() {
+        ImageMgrsCoordinate coord = new ImageMgrsCoordinate();
+        assertNotNull(coord);
+    }
+
+    @Test
+    public void testNullArgumentDMS() throws ParseException {
+        ImageMgrsCoordinate coord = new ImageMgrsCoordinate();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Null argument for MGRS parsing");
+        coord.setFromMgrs(null);
+    }
+
+    @Test
+    public void testValidArgumentDMS() throws ParseException {
+        ImageMgrsCoordinate coord = new ImageMgrsCoordinate();
+        coord.setFromMgrs("33BJK1234512345");
+        assertNotNull(coord);
+        assertThat(coord.getZone(), is(33));
+        assertThat(coord.getBand(), is("B"));
+        assertThat(coord.getGrid(), is("JK"));
+        assertThat(coord.getEasting(), is(12345));
+        assertThat(coord.getNorthing(), is(12345));
+        assertEquals("33BJK1234512345", coord.getSourceFormat());
+    }
+
+    @Test
+    public void testBadArgumentLengthDMS() throws ParseException {
+        ImageMgrsCoordinate coord = new ImageMgrsCoordinate();
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect length for MGRS String");
+        coord.setFromMgrs("33BJK12345123452");
+    }
+
+    @Test
+    public void testNumberFormatArgumentDMS() throws ParseException {
+        ImageMgrsCoordinate coord = new ImageMgrsCoordinate();
+        exception.expect(NumberFormatException.class);
+        exception.expectMessage("For input string: \"AA\"");
+        coord.setFromMgrs("AA3451234512345");
+    }
+
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/ImageUtmCoordinateTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/ImageUtmCoordinateTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.text.ParseException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ImageUtmCoordinateTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testImageCoordinatePairDefaultConstructor() {
+        ImageUtmCoordinate coord = new ImageUtmCoordinate(ImageCoordinatesRepresentation.UTMUPSNORTH);
+        assertNotNull(coord);
+    }
+
+    @Test
+    public void testNullArgumentDMS() throws ParseException {
+        ImageUtmCoordinate coord = new ImageUtmCoordinate(ImageCoordinatesRepresentation.UTMUPSNORTH);
+        exception.expect(ParseException.class);
+        exception.expectMessage("Null argument for UTM parsing");
+        coord.setFromUtmUps(null);
+    }
+
+    @Test
+    public void testValidArgumentDMS() throws ParseException {
+        ImageUtmCoordinate coord = new ImageUtmCoordinate(ImageCoordinatesRepresentation.UTMUPSNORTH);
+        coord.setFromUtmUps("331234561234567");
+        assertNotNull(coord);
+        assertThat(coord.getZone(), is(33));
+        assertThat(coord.getEasting(), is(123456));
+        assertThat(coord.getNorthing(), is(1234567));
+        assertEquals("331234561234567", coord.getSourceFormat());
+    }
+
+    @Test
+    public void testBadArgumentLengthDMS() throws ParseException {
+        ImageUtmCoordinate coord = new ImageUtmCoordinate(ImageCoordinatesRepresentation.UTMUPSNORTH);
+        exception.expect(ParseException.class);
+        exception.expectMessage("Incorrect length for UTM / UPS North String");
+        coord.setFromUtmUps("33BJK12345123452");
+    }
+
+    @Test
+    public void testNumberFormatArgumentDMS() throws ParseException {
+        ImageUtmCoordinate coord = new ImageUtmCoordinate(ImageCoordinatesRepresentation.UTMUPSNORTH);
+        exception.expect(NumberFormatException.class);
+        exception.expectMessage("For input string: \"AA\"");
+        coord.setFromUtmUps("AA1234561234567");
+    }
+
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -37,7 +37,6 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.codice.imaging.nitf.core.common.dataextension.NitfDataExtensionSegmentHeader;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,7 +85,7 @@ public class Nitf21HeaderTest {
 
     private void checkCompliantHeaderResults(SlottedNitfParseStrategy parseStrategy) {
         Nitf header = parseStrategy.getNitfHeader();
-        Assert.assertEquals(FileType.NITF_TWO_ONE, header.getFileType());
+        assertEquals(FileType.NITF_TWO_ONE, header.getFileType());
         assertEquals(3, header.getComplexityLevel());
         assertEquals("BF01", header.getStandardType());
         assertEquals("I_3034C", header.getOriginatingStationId());
@@ -118,14 +117,14 @@ public class Nitf21HeaderTest {
         assertEquals("Unknown", segment1.getImageSource());
         assertEquals(18L, segment1.getNumberOfRows());
         assertEquals(35L, segment1.getNumberOfColumns());
-        Assert.assertEquals(PixelValueType.BILEVEL, segment1.getPixelValueType());
-        Assert.assertEquals(ImageRepresentation.RGBLUT, segment1.getImageRepresentation());
-        Assert.assertEquals(ImageCategory.VISUAL, segment1.getImageCategory());
+        assertEquals(PixelValueType.BILEVEL, segment1.getPixelValueType());
+        assertEquals(ImageRepresentation.RGBLUT, segment1.getImageRepresentation());
+        assertEquals(ImageCategory.VISUAL, segment1.getImageCategory());
         assertEquals(1, segment1.getActualBitsPerPixelPerBand());
-        Assert.assertEquals(PixelJustification.RIGHT, segment1.getPixelJustification());
-        Assert.assertEquals(ImageCoordinatesRepresentation.NONE, segment1.getImageCoordinatesRepresentation());
+        assertEquals(PixelJustification.RIGHT, segment1.getPixelJustification());
+        assertEquals(ImageCoordinatesRepresentation.NONE, segment1.getImageCoordinatesRepresentation());
         assertEquals(0, segment1.getImageComments().size());
-        Assert.assertEquals(ImageCompression.NOTCOMPRESSED, segment1.getImageCompression());
+        assertEquals(ImageCompression.NOTCOMPRESSED, segment1.getImageCompression());
         assertEquals(1, segment1.getNumBands());
 
         // Checks for ImageBand
@@ -152,7 +151,7 @@ public class Nitf21HeaderTest {
         assertEquals((byte)0x00, lut3.getEntry(0));
         assertEquals((byte)0x00, lut3.getEntry(1));
 
-        Assert.assertEquals(ImageMode.BLOCKINTERLEVE, segment1.getImageMode());
+        assertEquals(ImageMode.BLOCKINTERLEVE, segment1.getImageMode());
         assertEquals(1, segment1.getNumberOfBlocksPerRow());
         assertEquals(1, segment1.getNumberOfBlocksPerColumn());
         assertEquals(35, segment1.getNumberOfPixelsPerBlockHorizontal());
@@ -214,7 +213,7 @@ public class Nitf21HeaderTest {
         assertEquals(8, segment1.getActualBitsPerPixelPerBand());
         assertEquals(PixelJustification.RIGHT, segment1.getPixelJustification());
         assertEquals(ImageCoordinatesRepresentation.GEOGRAPHIC, segment1.getImageCoordinatesRepresentation());
-        ImageCoordinates imageCoords = segment1.getImageCoordinates();
+        ImageCoordinates<ImageGeographicCoordinatePair> imageCoords = segment1.getImageCoordinates();
         assertNotNull(imageCoords);
         assertEquals(32.98333333333, imageCoords.getCoordinate00().getLatitude(), 0.000001);
         assertEquals(85.00000000000, imageCoords.getCoordinate00().getLongitude(), 0.000001);
@@ -356,7 +355,7 @@ public class Nitf21HeaderTest {
         assertEquals(8, segment1.getActualBitsPerPixelPerBand());
         assertEquals(PixelJustification.RIGHT, segment1.getPixelJustification());
         assertEquals(ImageCoordinatesRepresentation.DECIMALDEGREES, segment1.getImageCoordinatesRepresentation());
-        ImageCoordinates imageCoords = segment1.getImageCoordinates();
+        ImageCoordinates<ImageDecimalDegreesCoordinatePair> imageCoords = segment1.getImageCoordinates();
         assertNotNull(imageCoords);
         assertEquals(42.201, imageCoords.getCoordinate00().getLatitude(), 0.000001);
         assertEquals(-71.050, imageCoords.getCoordinate00().getLongitude(), 0.000001);
@@ -502,7 +501,7 @@ public class Nitf21HeaderTest {
         assertEquals("1998-02-17 10:19:39", formatter.format(textSegment.getTextDateTime().toDate()));
         assertEquals("                                                    Paragon Imaging Comment File", textSegment.getTextTitle());
         assertUnclasAndEmpty(textSegment.getSecurityMetadata());
-        Assert.assertEquals(TextFormat.BASICCHARACTERSET, textSegment.getTextFormat());
+        assertEquals(TextFormat.BASICCHARACTERSET, textSegment.getTextFormat());
     }
 
     @Test
@@ -630,7 +629,7 @@ public class Nitf21HeaderTest {
         assertEquals(100, segment.getGraphicLocationColumn());
         assertEquals(175, segment.getBoundingBox1Row());
         assertEquals(125, segment.getBoundingBox1Column());
-        Assert.assertEquals(GraphicColour.COLOUR, segment.getGraphicColour());
+        assertEquals(GraphicColour.COLOUR, segment.getGraphicColour());
         assertEquals(1075, segment.getBoundingBox2Row());
         assertEquals(825, segment.getBoundingBox2Column());
     }
@@ -884,7 +883,7 @@ public class Nitf21HeaderTest {
         assertEquals(1, imageSegment.getActualBitsPerPixelPerBand());
         assertEquals(PixelJustification.RIGHT, imageSegment.getPixelJustification());
         assertEquals(ImageCoordinatesRepresentation.DECIMALDEGREES, imageSegment.getImageCoordinatesRepresentation());
-        ImageCoordinates imageCoords = imageSegment.getImageCoordinates();
+        ImageCoordinates<ImageDecimalDegreesCoordinatePair> imageCoords = imageSegment.getImageCoordinates();
         assertNotNull(imageCoords);
         assertEquals(36.709, imageCoords.getCoordinate00().getLatitude(), 0.000001);
         assertEquals(67.105, imageCoords.getCoordinate00().getLongitude(), 0.000001);
@@ -941,7 +940,7 @@ public class Nitf21HeaderTest {
     }
 
     void assertUnclasAndEmpty(NitfSecurityMetadata securityMetadata) {
-        Assert.assertEquals(NitfSecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
+        assertEquals(NitfSecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
         assertEquals("", securityMetadata.getSecurityClassificationSystem());
         assertEquals("", securityMetadata.getCodewords());
         assertEquals("", securityMetadata.getControlAndHandling());

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21ImageParsingTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21ImageParsingTest.java
@@ -14,12 +14,12 @@
  **/
 package org.codice.imaging.nitf.core;
 
-import java.io.BufferedInputStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.InputStream;
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
@@ -77,7 +77,7 @@ public class Nitf21ImageParsingTest {
         assertEquals(8, imageSegment.getActualBitsPerPixelPerBand());
         assertEquals(PixelJustification.RIGHT, imageSegment.getPixelJustification());
         assertEquals(ImageCoordinatesRepresentation.GEOGRAPHIC, imageSegment.getImageCoordinatesRepresentation());
-        ImageCoordinates imageCoords = imageSegment.getImageCoordinates();
+        ImageCoordinates<ImageGeographicCoordinatePair> imageCoords = imageSegment.getImageCoordinates();
         assertNotNull(imageCoords);
         assertEquals(32.98333333333, imageCoords.getCoordinate00().getLatitude(), 0.000001);
         assertEquals(85.00000000000, imageCoords.getCoordinate00().getLongitude(), 0.000001);

--- a/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
+++ b/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
@@ -17,7 +17,7 @@ import java.util.TreeMap;
 
 import org.codice.imaging.nitf.core.FileReader;
 import org.codice.imaging.nitf.core.FileType;
-import org.codice.imaging.nitf.core.ImageCoordinatePair;
+import org.codice.imaging.nitf.core.ImageDecimalDegreesCoordinatePair;
 import org.codice.imaging.nitf.core.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.Nitf;
 import org.codice.imaging.nitf.core.NitfFileParser;
@@ -668,7 +668,7 @@ public class FileComparer {
     }
 
     // This is ugly - feel free to fix it any time.
-    private static String makeGeoString(ImageCoordinatePair coords) {
+    private static String makeGeoString(ImageDecimalDegreesCoordinatePair coords) {
         double latitude = coords.getLatitude();
         double longitude = coords.getLongitude();
 


### PR DESCRIPTION
… supports only ICORDS types G (geographic) and D (decimal degrees). Add parser support for U, N and S.

This change introduces some new classes for parsing/storing image coordinate information.  It also modifies the pom file to enforce jacoco code coverate rates and updates
the tests to cover the new ImageCoordinate classes.

@kcwire 
@bradh 

