### PR TITLE
Remove Oracle JDK 7 and OpenJDK 7 from Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ before_install: sudo pip install codecov
 install: mvn install --quiet -DskipTests=true -B
 script: mvn test --quiet -B
 jdk:
-  - openjdk7
-  - oraclejdk7
   - oraclejdk8
 after_success: codecov


### PR DESCRIPTION
@kcwire 
@dcruver 