### PR TITLE
img-58 Repackage text classes

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfConstants.java
@@ -616,6 +616,24 @@ public final class NitfConstants {
      */
     protected static final int TXSOFL_LENGTH = 3;
 
+    // Tagged Record Extension (TRE) segment
+    /**
+     * Length of the "Unique Extension Type Identifier" field in the Registered and controlled TRE format.
+     * <p>
+     * See MIL-STD-2500C Table A-7.
+     */
+    protected static final int TAG_LENGTH = 6;
+
+    /**
+     * Length of the "Length of REDATA Field" field in the Registered and controlled TRE format.
+     * <p>
+     * See MIL-STD-2500C Table A-7.
+     */
+    protected static final int TAGLEN_LENGTH = 5;
+
+    static final String AND_CONDITION = " AND ";
+    static final String UNSUPPORTED_IFTYPE_FORMAT_MESSAGE = "Unsupported format for iftype:";
+
     private NitfConstants() {
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/SlottedNitfParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/SlottedNitfParseStrategy.java
@@ -17,7 +17,9 @@ package org.codice.imaging.nitf.core;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.transform.Source;
+
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfReader;
@@ -31,6 +33,8 @@ import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreCollectionParser;
 import org.codice.imaging.nitf.core.label.LabelSegmentHeader;
 import org.codice.imaging.nitf.core.label.LabelSegmentHeaderParser;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextSegmentHeaderParser;
 
 /**
  * "Slotted" parse strategy.

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeaderParser.java
@@ -48,10 +48,10 @@ public class LabelSegmentHeaderParser extends AbstractNitfSegmentParser {
 
     /**
      *
-     * @param nitfReader the reader to use to get the data
-     * @param parseStrategy the parsing strategy to use to process the data
-     * @return the parsed header
-     * @throws ParseException on parse failure
+     * @param nitfReader the reader to use to get the data.
+     * @param parseStrategy the parsing strategy to use to process the data.
+     * @return the parsed header.
+     * @throws ParseException on parse failure.
      *
      */
     public final LabelSegmentHeader parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy) throws ParseException {

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextConstants.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+
+package org.codice.imaging.nitf.core.text;
+
+final class TextConstants {
+
+    private TextConstants() {
+    }
+
+    /**
+     * Marker string for NITF Text subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final String TE = "TE";
+
+    /**
+     * Length of the "Text Identifier" field in the NITF 2.1 Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TEXTID_LENGTH = 7;
+
+    /**
+     * Length of the "Text Attachment Level" field in the NITF Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TXTALVL_LENGTH = 3;
+
+    /**
+     * Length of the "Text Identifier" field in the NITF 2.0 Text Subheader.
+     * <p>
+     * See MIL-STD-2500A.
+     */
+    protected static final int TEXTID20_LENGTH = 10;
+
+    /**
+     * Length of the "Text Title" field in the NITF Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TXTITL_LENGTH = 80;
+
+    /**
+     * Length of the "Text Format" field in the NITF Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TXTFMT_LENGTH = 3;
+
+    /**
+     * Length of the "Text Extended Subheader Data Length" field in the NITF Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TXSHDL_LENGTH = 5;
+
+    /**
+     * Length of the "Text Extended Subheader Overflow" field in the NITF Text Subheader.
+     * <p>
+     * See MIL-STD-2500C Table A-6.
+     */
+    protected static final int TXSOFL_LENGTH = 3;
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextDataExtractionParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextDataExtractionParseStrategy.java
@@ -12,9 +12,11 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.text;
 
 import java.text.ParseException;
+
+import org.codice.imaging.nitf.core.SlottedNitfParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfReader;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextFormat.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextFormat.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.text;
 
 /**
     Text format.

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+
+package org.codice.imaging.nitf.core.text;
+
+import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.NitfDateTime;
+
+/**
+ * Represents a Nitf TextSegmentHeader.
+ */
+public interface TextSegmentHeader extends CommonNitfSubSegment {
+
+    /**
+     Return text date and time.
+     <p>
+     This field shall contain the time (UTC) (Zulu) of origination of the text.
+
+     @return the date and time of the text.
+     */
+    NitfDateTime getTextDateTime();
+
+    /**
+     Return text title.
+     <p>
+     This field shall contain the title of the text item.
+
+     @return text title
+     */
+    String getTextTitle();
+
+    /**
+     Return the text format indicator.
+     <p>
+     See TextFormat for the meaning of the enumerated values.
+
+     @return the text format
+     */
+    TextFormat getTextFormat();
+
+    /**
+     Return the text data length.
+
+     @return the text data segment length, in bytes
+     */
+    int getTextDataLength();
+
+    /**
+     Set the text segment data length.
+     <p>
+     This is the length of the contents of the associated data segment.
+
+     @param dataLength the text data segment length, in bytes
+     */
+    void setTextSegmentDataLength(int dataLength);
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderImpl.java
@@ -12,14 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.text;
 
+import org.codice.imaging.nitf.core.AbstractNitfSubSegment;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 
 /**
     Text segment subheader information.
 */
-public class TextSegmentHeader extends AbstractNitfSubSegment {
+class TextSegmentHeaderImpl extends AbstractNitfSubSegment implements TextSegmentHeader {
 
     private NitfDateTime textDateTime = null;
     private String textTitle = null;
@@ -29,7 +30,7 @@ public class TextSegmentHeader extends AbstractNitfSubSegment {
     /**
         Default constructor.
     */
-    public TextSegmentHeader() {
+    public TextSegmentHeaderImpl() {
     }
 
     /**
@@ -44,12 +45,9 @@ public class TextSegmentHeader extends AbstractNitfSubSegment {
     }
 
     /**
-        Return text date and time.
-        <p>
-        This field shall contain the time (UTC) (Zulu) of origination of the text.
-
-        @return the date and time of the text.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final NitfDateTime getTextDateTime() {
         return textDateTime;
     }
@@ -66,12 +64,9 @@ public class TextSegmentHeader extends AbstractNitfSubSegment {
     }
 
     /**
-        Return text title.
-        <p>
-        This field shall contain the title of the text item.
-
-        @return text title
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final String getTextTitle() {
         return textTitle;
     }
@@ -88,32 +83,24 @@ public class TextSegmentHeader extends AbstractNitfSubSegment {
     }
 
     /**
-        Return the text format indicator.
-        <p>
-        See TextFormat for the meaning of the enumerated values.
-
-        @return the text format
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final TextFormat getTextFormat() {
         return textFormat;
     }
 
     /**
-        Set the text segment data length.
-        <p>
-        This is the length of the contents of the associated data segment.
-
-        @param length the text data segment length, in bytes
-    */
+     * {@inheritDoc}
+     */
     public final void setTextSegmentDataLength(final int length) {
         textSegmentDataLength = length;
     }
 
     /**
-        Return the text data length.
-
-        @return the text data segment length, in bytes
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final int getTextDataLength() {
         return textSegmentDataLength;
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderParser.java
@@ -12,10 +12,20 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.text;
+
+import static org.codice.imaging.nitf.core.text.TextConstants.TE;
+import static org.codice.imaging.nitf.core.text.TextConstants.TEXTID20_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TEXTID_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TXSHDL_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TXSOFL_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TXTALVL_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TXTFMT_LENGTH;
+import static org.codice.imaging.nitf.core.text.TextConstants.TXTITL_LENGTH;
 
 import java.text.ParseException;
 
+import org.codice.imaging.nitf.core.SecurityMetadata;
 import org.codice.imaging.nitf.core.common.AbstractNitfSegmentParser;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfParseStrategy;
@@ -25,18 +35,30 @@ import org.codice.imaging.nitf.core.tre.TreCollection;
 /**
     Parser for a text segment subheader in a NITF file.
 */
-class TextSegmentHeaderParser extends AbstractNitfSegmentParser {
+public class TextSegmentHeaderParser extends AbstractNitfSegmentParser {
 
     private int textExtendedSubheaderLength = 0;
 
-    private TextSegmentHeader segment = null;
+    private TextSegmentHeaderImpl segment = null;
 
-    TextSegmentHeaderParser() {
+    /**
+     * default constructor.
+     */
+    public TextSegmentHeaderParser() {
     }
 
-    final TextSegmentHeader parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy) throws ParseException {
+    /**
+     * Parses the TextSegmentHeader from the give NitfReader.
+     *
+     * @param nitfReader The NitfReader to read TextSegmentHeader from.
+     * @param parseStrategy the parsing strategy to use to process the data.
+     * @return the parsed TextSegmentHeader.
+     * @throws ParseException when the input from the NitfReader isn't what was expected.
+     */
+    public final TextSegmentHeader parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy)
+            throws ParseException {
         reader = nitfReader;
-        segment = new TextSegmentHeader();
+        segment = new TextSegmentHeaderImpl();
         parsingStrategy = parseStrategy;
 
         readTE();
@@ -56,17 +78,17 @@ class TextSegmentHeaderParser extends AbstractNitfSegmentParser {
     }
 
     private void readTE() throws ParseException {
-       reader.verifyHeaderMagic(NitfConstants.TE);
+       reader.verifyHeaderMagic(TE);
     }
 
     private void readTEXTID() throws ParseException {
         switch (reader.getFileType()) {
             case NITF_TWO_ZERO:
-                segment.setIdentifier(reader.readBytes(NitfConstants.TEXTID20_LENGTH));
+                segment.setIdentifier(reader.readBytes(TEXTID20_LENGTH));
                 break;
             case NITF_TWO_ONE:
             case NSIF_ONE_ZERO:
-                segment.setIdentifier(reader.readBytes(NitfConstants.TEXTID_LENGTH));
+                segment.setIdentifier(reader.readBytes(TEXTID_LENGTH));
                 break;
             case UNKNOWN:
             default:
@@ -76,7 +98,7 @@ class TextSegmentHeaderParser extends AbstractNitfSegmentParser {
 
     private void readTXTALVL() throws ParseException {
         if ((reader.getFileType() == FileType.NITF_TWO_ONE) || (reader.getFileType() == FileType.NSIF_ONE_ZERO)) {
-            segment.setAttachmentLevel(reader.readBytesAsInteger(NitfConstants.TXTALVL_LENGTH));
+            segment.setAttachmentLevel(reader.readBytesAsInteger(TXTALVL_LENGTH));
         }
     }
 
@@ -85,24 +107,24 @@ class TextSegmentHeaderParser extends AbstractNitfSegmentParser {
     }
 
     private void readTXTITL() throws ParseException {
-        segment.setTextTitle(reader.readTrimmedBytes(NitfConstants.TXTITL_LENGTH));
+        segment.setTextTitle(reader.readTrimmedBytes(TXTITL_LENGTH));
     }
 
     private void readTXTFMT() throws ParseException {
-        String txtfmt = reader.readTrimmedBytes(NitfConstants.TXTFMT_LENGTH);
+        String txtfmt = reader.readTrimmedBytes(TXTFMT_LENGTH);
         segment.setTextFormat(TextFormat.getEnumValue(txtfmt));
     }
 
     private void readTXSHDL() throws ParseException {
-        textExtendedSubheaderLength = reader.readBytesAsInteger(NitfConstants.TXSHDL_LENGTH);
+        textExtendedSubheaderLength = reader.readBytesAsInteger(TXSHDL_LENGTH);
     }
 
     private void readTXSOFL() throws ParseException {
-        segment.setExtendedHeaderDataOverflow(reader.readBytesAsInteger(NitfConstants.TXSOFL_LENGTH));
+        segment.setExtendedHeaderDataOverflow(reader.readBytesAsInteger(TXSOFL_LENGTH));
     }
 
     private void readTXSHD() throws ParseException {
-        TreCollection extendedSubheaderTREs = parsingStrategy.parseTREs(reader, textExtendedSubheaderLength - NitfConstants.TXSOFL_LENGTH);
+        TreCollection extendedSubheaderTREs = parsingStrategy.parseTREs(reader, textExtendedSubheaderLength - TXSOFL_LENGTH);
         segment.mergeTREs(extendedSubheaderTREs);
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
@@ -38,6 +38,9 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
 import org.codice.imaging.nitf.core.label.LabelSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextDataExtractionParseStrategy;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
@@ -37,6 +37,8 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
 import org.codice.imaging.nitf.core.label.LabelSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -52,6 +52,8 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageBandLUT;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreEntry;

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
@@ -35,6 +35,8 @@ import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21TextParsingTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21TextParsingTest.java
@@ -27,6 +27,9 @@ import java.util.TimeZone;
 
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
+import org.codice.imaging.nitf.core.text.TextDataExtractionParseStrategy;
+import org.codice.imaging.nitf.core.text.TextFormat;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/DeferredSegmentParseStrategy.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/DeferredSegmentParseStrategy.java
@@ -26,7 +26,7 @@ import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
 import org.codice.imaging.nitf.core.label.LabelSegmentHeader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.SymbolSegmentHeader;
-import org.codice.imaging.nitf.core.TextSegmentHeader;
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.codice.imaging.nitf.core.SlottedNitfParseStrategy;
 import org.codice.imaging.nitf.core.dataextension.NitfDataExtensionSegmentHeader;
 import org.codice.imaging.nitf.core.graphic.NitfGraphicSegmentHeader;

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfTextSegmentNode.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfTextSegmentNode.java
@@ -16,7 +16,8 @@ package org.codice.imaging.nitf.nitfnetbeansfiletype;
 
 import java.text.ParseException;
 import javax.swing.Action;
-import org.codice.imaging.nitf.core.TextSegmentHeader;
+
+import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.openide.nodes.Children;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;


### PR DESCRIPTION
This change introduces the org.codice.nitf.imaging.core.text package and moves
the TextHeaderSegment and related classes into it.

@bradh 
@kcwire 