### PR TITLE
[IMG-54] Move PixelValueType and PixelJustification enums to image package

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeader.java
@@ -16,8 +16,6 @@ package org.codice.imaging.nitf.core.image;
 
 import java.util.List;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
-import org.codice.imaging.nitf.core.PixelJustification;
-import org.codice.imaging.nitf.core.PixelValueType;
 import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderImpl.java
@@ -18,8 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.codice.imaging.nitf.core.AbstractNitfSubSegment;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
-import org.codice.imaging.nitf.core.PixelJustification;
-import org.codice.imaging.nitf.core.PixelValueType;
 
 /**
     Image segment subheader information.

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParser.java
@@ -54,8 +54,6 @@ import java.text.ParseException;
 import java.util.EnumSet;
 import java.util.Set;
 
-import org.codice.imaging.nitf.core.PixelJustification;
-import org.codice.imaging.nitf.core.PixelValueType;
 import org.codice.imaging.nitf.core.common.AbstractNitfSegmentParser;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfParseStrategy;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/PixelJustification.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/PixelJustification.java
@@ -12,45 +12,36 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.image;
 
 /**
-    Pixel value type (PVTYPE).
+    Pixel justification (PJUST) options.
+    <p>
+    NITF images can have different "actual bits per pixel" to "number of
+    bits per pixel" (e.g. 12 bits per pixel packed into 16 bits). To determine
+    where the data (as opposed to the padding) is to be found, there is a
+    pixel justification (left or right) setting.
 */
-public enum PixelValueType {
-
+public enum PixelJustification {
     /**
-        Unknown pixel value type.
+        Unknown justification.
         <p>
-        This indicates an unknown format, and typically indicates a broken file or
-        an error during parsing. This is not a valid value in a NITF image.
+        This indicates an unknown justification, and typically indicates a broken file or
+        an error during parsing. This is not a valid value in a NITF .
     */
     UNKNOWN (""),
 
     /**
-        Integer.
+        Left justification.
     */
-    INTEGER ("INT"),
+    LEFT ("L"),
 
     /**
-        Bi-level.
+        Right justification.
+        <p>
+        This is the preferred setting.
     */
-    BILEVEL ("B"),
-
-    /**
-        Signed integer.
-    */
-    SIGNEDINTEGER ("SI"),
-
-    /**
-        Real (floating point).
-    */
-    REAL ("R"),
-
-    /**
-        Complex (real and imaginary floating point).
-    */
-    COMPLEX ("C");
+    RIGHT ("R");
 
     private final String textEquivalent;
 
@@ -61,35 +52,35 @@ public enum PixelValueType {
 
         @param abbreviation the text abbreviation for the enumeration value.
     */
-    PixelValueType(final String abbreviation) {
-        this.textEquivalent = abbreviation;
+    PixelJustification(final String abbreviation) {
+        textEquivalent = abbreviation;
     }
 
     /**
-        Create pixel value type from the text equivalent.
+        Create pixel justification from the text equivalent.
         <p>
         This is intended to support file parsing, and is not usually necessary
         for other purposes.
 
-        @param textEquivalent the text equivalent for a pixel value type
-        @return the pixel value type enumerated value.
+        @param textEquivalent the single character text equivalent for pixel justification.
+        @return the pixel justification enumerated value.
     */
-    public static PixelValueType getEnumValue(final String textEquivalent) {
-        for (PixelValueType pv : values()) {
-            if (textEquivalent.equals(pv.textEquivalent)) {
-                return pv;
+    public static PixelJustification getEnumValue(final String textEquivalent) {
+        for (PixelJustification pj : values()) {
+            if (textEquivalent.equals(pj.textEquivalent)) {
+                return pj;
             }
         }
         return UNKNOWN;
     }
 
     /**
-        Return the text equivalent for a pixel value type.
+        Return the text equivalent for a pixel justification
         <p>
         This is intended for debug output and output writing, and is not usually
         necessary for other purposes.
 
-        @return the text equivalent for a pixel value type.
+        @return the single character text equivalent for a pixel justification.
     */
     public String getTextEquivalent() {
         return textEquivalent;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/PixelValueType.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/PixelValueType.java
@@ -12,36 +12,45 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.image;
 
 /**
-    Pixel justification (PJUST) options.
-    <p>
-    NITF images can have different "actual bits per pixel" to "number of
-    bits per pixel" (e.g. 12 bits per pixel packed into 16 bits). To determine
-    where the data (as opposed to the padding) is to be found, there is a
-    pixel justification (left or right) setting.
+    Pixel value type (PVTYPE).
 */
-public enum PixelJustification {
+public enum PixelValueType {
+
     /**
-        Unknown justification.
+        Unknown pixel value type.
         <p>
-        This indicates an unknown justification, and typically indicates a broken file or
-        an error during parsing. This is not a valid value in a NITF .
+        This indicates an unknown format, and typically indicates a broken file or
+        an error during parsing. This is not a valid value in a NITF image.
     */
     UNKNOWN (""),
 
     /**
-        Left justification.
+        Integer.
     */
-    LEFT ("L"),
+    INTEGER ("INT"),
 
     /**
-        Right justification.
-        <p>
-        This is the preferred setting.
+        Bi-level.
     */
-    RIGHT ("R");
+    BILEVEL ("B"),
+
+    /**
+        Signed integer.
+    */
+    SIGNEDINTEGER ("SI"),
+
+    /**
+        Real (floating point).
+    */
+    REAL ("R"),
+
+    /**
+        Complex (real and imaginary floating point).
+    */
+    COMPLEX ("C");
 
     private final String textEquivalent;
 
@@ -52,35 +61,35 @@ public enum PixelJustification {
 
         @param abbreviation the text abbreviation for the enumeration value.
     */
-    PixelJustification(final String abbreviation) {
-        textEquivalent = abbreviation;
+    PixelValueType(final String abbreviation) {
+        this.textEquivalent = abbreviation;
     }
 
     /**
-        Create pixel justification from the text equivalent.
+        Create pixel value type from the text equivalent.
         <p>
         This is intended to support file parsing, and is not usually necessary
         for other purposes.
 
-        @param textEquivalent the single character text equivalent for pixel justification.
-        @return the pixel justification enumerated value.
+        @param textEquivalent the text equivalent for a pixel value type
+        @return the pixel value type enumerated value.
     */
-    public static PixelJustification getEnumValue(final String textEquivalent) {
-        for (PixelJustification pj : values()) {
-            if (textEquivalent.equals(pj.textEquivalent)) {
-                return pj;
+    public static PixelValueType getEnumValue(final String textEquivalent) {
+        for (PixelValueType pv : values()) {
+            if (textEquivalent.equals(pv.textEquivalent)) {
+                return pv;
             }
         }
         return UNKNOWN;
     }
 
     /**
-        Return the text equivalent for a pixel justification
+        Return the text equivalent for a pixel value type.
         <p>
         This is intended for debug output and output writing, and is not usually
         necessary for other purposes.
 
-        @return the single character text equivalent for a pixel justification.
+        @return the text equivalent for a pixel value type.
     */
     public String getTextEquivalent() {
         return textEquivalent;

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
@@ -14,6 +14,8 @@
  **/
 package org.codice.imaging.nitf.core;
 
+import org.codice.imaging.nitf.core.image.PixelValueType;
+import org.codice.imaging.nitf.core.image.PixelJustification;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
@@ -14,6 +14,8 @@
  **/
 package org.codice.imaging.nitf.core;
 
+import org.codice.imaging.nitf.core.image.PixelValueType;
+import org.codice.imaging.nitf.core.image.PixelJustification;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -14,6 +14,8 @@
  **/
 package org.codice.imaging.nitf.core;
 
+import org.codice.imaging.nitf.core.image.PixelValueType;
+import org.codice.imaging.nitf.core.image.PixelJustification;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
@@ -14,6 +14,8 @@
  **/
 package org.codice.imaging.nitf.core;
 
+import org.codice.imaging.nitf.core.image.PixelValueType;
+import org.codice.imaging.nitf.core.image.PixelJustification;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/Nitf21ImageParsingTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/Nitf21ImageParsingTest.java
@@ -26,8 +26,6 @@ import org.codice.imaging.nitf.core.HeaderOnlyNitfParseStrategy;
 import org.codice.imaging.nitf.core.NitfFileParser;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
-import org.codice.imaging.nitf.core.PixelJustification;
-import org.codice.imaging.nitf.core.PixelValueType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParserTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParserTest.java
@@ -27,8 +27,6 @@ import org.codice.imaging.nitf.core.common.NitfParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.security.SecurityClassification;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
-import org.codice.imaging.nitf.core.PixelJustification;
-import org.codice.imaging.nitf.core.PixelValueType;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
@@ -27,7 +27,7 @@ import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
-import org.codice.imaging.nitf.core.PixelJustification;
+import org.codice.imaging.nitf.core.image.PixelJustification;
 
 public class UncompressedBlockRenderer implements BlockRenderer {
 


### PR DESCRIPTION
This is left-over scope from IMG-54.

@dcruver Can you check that this is consistent with your refactoring intent?