### PR TITLE
img-80 render module name uses nitf-imaging instead of imaging-nitf.

### DIFF
--- a/nitfNetbeansFileType/pom.xml
+++ b/nitfNetbeansFileType/pom.xml
@@ -145,7 +145,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>codice-nitf-imaging-render</artifactId>
+            <artifactId>codice-imaging-nitf-render</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/render/pom.xml
+++ b/render/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <groupId>org.codice.imaging.nitf</groupId>
-    <artifactId>codice-nitf-imaging-render</artifactId>
+    <artifactId>codice-imaging-nitf-render</artifactId>
     <version>0.2-SNAPSHOT</version>
 
     <name>Codice Imaging: NITF Render</name>


### PR DESCRIPTION
Changed the name in both affected pom.xml files.

@bradh
@kcwire 