### PR TITLE
img-78 NitfRenderer shuts down the JVM when it encounters an unrecogn…

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -56,10 +56,8 @@ public class NitfRenderer {
             renderJPEG(imageSegmentHeader, imageData, targetGraphic, imageMask);
             break;
         default:
-            System.out.println("Unhandled image compression format: "
+            throw new UnsupportedOperationException("Unhandled image compression format: "
                     + imageSegmentHeader.getImageCompression());
-            System.exit(0);
-            break;
         }
     }
 


### PR DESCRIPTION
…ized compression scheme.

This change replaces the System.exit(0) statement with an UnsupportedOperationException.

@bradh 
@kcwire 