### PR TITLE
img-82 Missing copyright headers on files

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/AbstractNitfSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/AbstractNitfSegment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core;
 
 import java.util.List;

--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfConstants.java
@@ -1,14 +1,15 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
- * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation, either version 3 of the License, or any later version.
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is
- * distributed along with this program and can be found at
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- *
  *
  */
 package org.codice.imaging.nitf.core;

--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfReaderDefaultImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfReaderDefaultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core;
 
 import java.nio.charset.Charset;

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.common;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonNitfSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonNitfSegment.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.common;
 
 import java.util.Map;

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CoordinateConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CoordinateConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.common;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/FileType.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/FileType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.common;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/NitfReader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/NitfReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.common;
 
 import java.text.ParseException;

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.dataextension;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/NitfDataExtensionSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/NitfDataExtensionSegmentHeaderParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.dataextension;
 
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.DE;

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentConstants.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.core.graphic;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,8 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
-
+ */
 package org.codice.imaging.nitf.core.graphic;
 
 import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.graphic;
 
 import org.codice.imaging.nitf.core.AbstractNitfSubSegment;

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/NitfGraphicSegmentHeaderParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.graphic;
 
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SALVL_LENGTH;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageCategory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,8 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
-
+ */
 package org.codice.imaging.nitf.core.image;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageBandParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageBandParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 import static org.codice.imaging.nitf.core.image.ImageConstants.IFC_LENGTH;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/NitfImageSegmentHeaderParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 import static org.codice.imaging.nitf.core.image.ImageConstants.ABPP_LENGTH;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/PixelJustification.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/PixelJustification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/RasterProductFormatUtilities.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/RasterProductFormatUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 import java.io.IOException;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/TargetId.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/TargetId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.image;
 
 import java.text.ParseException;

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.label;
 
 final class LabelConstants {

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeader.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.label;
 
 import org.codice.imaging.nitf.core.RGBColour;

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeaderParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentHeaderParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.label;
 
 import static org.codice.imaging.nitf.core.label.LabelConstants.LA;

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadata.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.core.security;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadataParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadataParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityClassification.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityClassification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.security;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,8 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
-
+ */
 package org.codice.imaging.nitf.core.security;
 
 final class SecurityConstants {

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadata.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,8 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
-
+ */
 package org.codice.imaging.nitf.core.security;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.security;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.security;
 
 import java.text.ParseException;

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolColour.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolColour.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.symbol;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolConstants.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.symbol;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentHeader.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.core.symbol;
 
 import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentHeaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.symbol;
 
 import org.codice.imaging.nitf.core.AbstractNitfSubSegment;

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextConstants.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.core.text;
 
 final class TextConstants {

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextFormat.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.text;
 
 /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeader.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.core.text;
 
 import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentHeaderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) Codice Foundation
  *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -11,7 +11,7 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ */
 package org.codice.imaging.nitf.core.text;
 
 import org.codice.imaging.nitf.core.AbstractNitfSubSegment;

--- a/render/src/main/java/org/codice/imaging/nitf/render/BlockConsumer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/BlockConsumer.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.render;
 
 import java.io.IOException;

--- a/render/src/main/java/org/codice/imaging/nitf/render/BlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/BlockRenderer.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.io.IOException;

--- a/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.io.IOException;

--- a/render/src/main/java/org/codice/imaging/nitf/render/JpegMarkerCode.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/JpegMarkerCode.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.render;
 
 public enum JpegMarkerCode {

--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.awt.Graphics2D;

--- a/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.awt.image.BufferedImage;

--- a/render/src/main/java/org/codice/imaging/nitf/render/VectorQuantizationBlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/VectorQuantizationBlockRenderer.java
@@ -12,7 +12,6 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.io.IOException;

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfParserInputFlow.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfParserInputFlow.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.render.flow;
 
 import java.io.File;

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfParserParsingFlow.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfParserParsingFlow.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.render.flow;
 
 import java.text.ParseException;

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
 package org.codice.imaging.nitf.render.flow;
 
 import java.io.ByteArrayInputStream;

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
@@ -16,7 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301  USA
  */
-
 package org.codice.imaging.nitf.render;
 
 import java.awt.image.BufferedImage;


### PR DESCRIPTION
Added missing copyright headers and standardized others (switched /** to /*).  Also,
removed whitespace between the copyright and the package statement when necessary.