### PR TITLE
img-73 Add support for RGB24:BANDSEQUENTIAL encoded images.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
@@ -21,7 +21,7 @@ import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
 
-final class ImageMask {
+public final class ImageMask {
 
     private NitfImageSegmentHeader mImageSegmentHeader = null;
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -12,21 +12,40 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
+
 package org.codice.imaging.nitf.render;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
+
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
+
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.codice.imaging.nitf.render.imagehandler.BandSequentialImageModeHandler;
+import org.codice.imaging.nitf.render.imagehandler.ImageModeHandler;
+import org.codice.imaging.nitf.render.imagehandler.ImageRepresentationHandler;
 
 /**
  * Renderer for NITF files
  */
 public class NitfRenderer {
+
+    private final static Map<ImageMode, ImageModeHandler> IMAGE_MODE_HANDLER_MAP = new HashMap<>();
+    private final static Map<ImageRepresentation, ImageRepresentationHandler> IMAGE_REPRESENTATION_HANDLER_MAP = new HashMap<>();
+
+    static {
+        IMAGE_MODE_HANDLER_MAP.put(ImageMode.BANDSEQUENTIAL, new BandSequentialImageModeHandler());
+        IMAGE_REPRESENTATION_HANDLER_MAP.put(ImageRepresentation.RGBTRUECOLOUR, (currentValue, bandValue, bandIndex) ->
+                currentValue | (bandValue << (8 * (2 - bandIndex))) );
+    }
 
     /**
      * Render to the specified Graphics2D target.
@@ -44,10 +63,15 @@ public class NitfRenderer {
             break;
         case NOTCOMPRESSED:
         case NOTCOMPRESSEDMASK:
-            render(new UncompressedBlockRenderer(),
-                    imageSegmentHeader,
-                    imageData,
-                    targetGraphic);
+            ImageModeHandler modeHandler = IMAGE_MODE_HANDLER_MAP.get(imageSegmentHeader.getImageMode());
+            ImageRepresentationHandler representationHandler = IMAGE_REPRESENTATION_HANDLER_MAP.get(imageSegmentHeader.getImageRepresentation());
+
+            if (modeHandler != null && representationHandler != null) {
+                modeHandler.handleImage(imageSegmentHeader, imageData, targetGraphic, representationHandler);
+            } else {
+                render(new UncompressedBlockRenderer(), imageSegmentHeader, imageData, targetGraphic);
+            }
+
             break;
         case DOWNSAMPLEDJPEG:
         case JPEG:

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/BandSequentialImageModeHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagehandler;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
+import java.io.IOException;
+import java.nio.IntBuffer;
+import java.util.function.Consumer;
+
+import javax.imageio.stream.ImageInputStream;
+
+import org.codice.imaging.nitf.core.image.ImageCompression;
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.codice.imaging.nitf.render.ImageMask;
+
+public class BandSequentialImageModeHandler implements ImageModeHandler {
+    private static final String NULL_ARG_ERROR_MESSAGE =
+            "BandSequentialImageModeHandler(): constructor argument '%s' may not be null.";
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleImage(NitfImageSegmentHeader imageSegmentHeader,
+            ImageInputStream imageInputStream, Graphics2D targetImage,
+            ImageRepresentationHandler imageRepresentationHandler) throws IOException {
+
+        checkNull(imageInputStream, "imageInputStream");
+        checkNull(imageSegmentHeader, "imageSegmentHeader");
+        checkNull(targetImage, "targetImage");
+        checkNull(imageRepresentationHandler, "imageRepresentationHandler");
+
+        ImageMask iMask = null;
+
+        if (ImageCompression.NOTCOMPRESSEDMASK.equals(imageSegmentHeader.getImageCompression())) {
+            iMask = new ImageMask(imageSegmentHeader, imageInputStream);
+        } else {
+            iMask = new ImageMask(imageSegmentHeader);
+        }
+
+        final ImageMask imageMask = iMask;
+
+        if (!ImageMode.BANDSEQUENTIAL.equals(imageSegmentHeader.getImageMode())) {
+            throw new IllegalStateException(
+                    "BandSequentialImageModeHandler(): constructor argument 'imageSegmentHeader' must have be ImageMode of 'S'.");
+        }
+
+        ImageBlockMatrix matrix = new ImageBlockMatrix(imageSegmentHeader.getNumberOfBlocksPerColumn(), imageSegmentHeader.getNumberOfBlocksPerRow(),
+                imageSegmentHeader.getNumberOfPixelsPerBlockHorizontal() * imageSegmentHeader.getNumberOfPixelsPerBlockVertical());
+
+        for (int bandIndex = 0; bandIndex < imageSegmentHeader.getNumBands(); bandIndex++) {
+            final int index = bandIndex;
+
+            forEachBlock(imageSegmentHeader, matrix, block -> readBlock(imageSegmentHeader, block, imageInputStream,
+                            imageRepresentationHandler, index, imageMask));
+        }
+
+        forEachBlock(imageSegmentHeader, matrix, block -> { renderBlock(imageSegmentHeader, targetImage, block);
+            block.getData().clear(); } );
+    }
+
+    private void checkNull(Object value, String valueName) {
+        if (value == null) {
+            throw new IllegalArgumentException(String.format(NULL_ARG_ERROR_MESSAGE, valueName));
+        }
+    }
+
+    private void forEachBlock(NitfImageSegmentHeader imageSegmentHeader, ImageBlockMatrix matrix, Consumer<ImageBlock> intBufferConsumer)
+        throws IOException {
+        for (int i = 0; i < imageSegmentHeader.getNumberOfBlocksPerColumn(); i++) {
+            for (int j = 0; j < imageSegmentHeader.getNumberOfBlocksPerRow(); j++) {
+                ImageBlock currentBlock = matrix.getImageBlock(i, j);
+                intBufferConsumer.accept(currentBlock);
+            }
+        }
+    }
+
+    private void readBlock(NitfImageSegmentHeader imageSegmentHeader, ImageBlock block,
+            ImageInputStream imageInputStream, ImageRepresentationHandler imageRepresentationHandler, int bandIndex,
+            ImageMask imageMask) {
+
+        final IntBuffer data = block.getData();
+        final int blockHeight = imageSegmentHeader.getNumberOfPixelsPerBlockVertical();
+        final int blockWidth = imageSegmentHeader.getNumberOfPixelsPerBlockHorizontal();
+
+        try {
+            for (int row = 0; row < blockHeight; row++) {
+                for (int column = 0; column < blockWidth; column++) {
+                    int i = row * blockWidth + column;
+                    int bandValue = imageInputStream.read();
+                    data.put(i, imageRepresentationHandler.renderPixel(data.get(i), bandValue, bandIndex));
+                }
+            }
+
+            applyMask(block, imageMask);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void renderBlock(NitfImageSegmentHeader imageSegmentHeader, Graphics2D targetImage, ImageBlock block ) {
+        final int blockWidth = imageSegmentHeader.getNumberOfPixelsPerBlockHorizontal();
+        final int blockHeight = imageSegmentHeader.getNumberOfPixelsPerBlockVertical();
+
+        BufferedImage img = new BufferedImage(blockWidth, blockHeight, BufferedImage.TYPE_INT_ARGB);
+        int[] imgData = ((DataBufferInt) img.getRaster().getDataBuffer()).getData();
+        System.arraycopy(block.getData().array(), 0, imgData, 0, block.getData().array().length);
+        targetImage.drawImage(img, block.getColumn() * blockHeight, block.getRow() * blockWidth, null);
+    }
+
+    private void applyMask(ImageBlock block, ImageMask imageMask) throws IOException {
+        final IntBuffer data = block.getData();
+        final int dataSize = data.array().length;
+
+        if (imageMask != null) {
+            for (int pixel = 0; pixel < dataSize; ++pixel) {
+                data.put(pixel, data.get(pixel) | 0xFF000000);
+
+                if (imageMask.isPadPixel(data.get(pixel))) {
+                    data.put(pixel, 0x00000000);
+                }
+            }
+        } else {
+            for (int pixel = 0; pixel < dataSize; ++pixel) {
+                data.put(pixel, data.get(pixel) | 0xFF000000);
+            }
+        }
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageBlock.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageBlock.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagehandler;
+
+import java.nio.IntBuffer;
+
+/**
+ * An ImageBlock represents a single block of a larger image.
+ */
+class ImageBlock {
+    private int row;
+    private int column;
+    private IntBuffer data;
+
+    /**
+     *
+     * @param row - the row position of this ImageBlock in the larger image.
+     * @param column - the column position of this ImageBlock in the larger image.
+     * @param blockSize - the size of this block.
+     */
+    public ImageBlock(int row, int column, int blockSize) {
+        this.row = row;
+        this.column = column;
+        this.data = IntBuffer.allocate(blockSize);
+    }
+
+    /**
+     *
+     * @return the row position of this ImageBlock in the larger image.
+     */
+    public int getRow() {
+        return row;
+    }
+
+    /**
+     *
+     * @return the column position of this ImageBlock in the larger image.
+     */
+    public int getColumn() {
+        return column;
+    }
+
+    /**
+     *
+     * @return the IntBuffer that contains the data for this ImageBlock.
+     */
+    public IntBuffer getData() {
+        return data;
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageBlockMatrix.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageBlockMatrix.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagehandler;
+
+/**
+ * The ImageMatrix represents image data stored in a rowcount x columncount matrix.
+ */
+class ImageBlockMatrix {
+    private ImageBlock[][] blocks;
+
+    /**
+     *
+     * @param rowCount - the number of rows in the matrix.
+     * @param columnCount - the number of columns in each matrix row.
+     * @param blockSize - the size of a single block in the matrix.
+     */
+    public ImageBlockMatrix(int rowCount, int columnCount, int blockSize) {
+        blocks = new ImageBlock[rowCount][columnCount];
+
+        for (int i = 0; i < rowCount; i++) {
+            for (int j = 0; j < columnCount; j++) {
+                blocks[i][j] = new ImageBlock(i, j, blockSize);
+            }
+        }
+    }
+
+    /**
+     *
+     * @param row - the row to retrieve the ImageBlock from.
+     * @param column - the column to retrieve the ImageBlock from.
+     * @return - the ImageBlock referenced by (row, column).
+     */
+    public ImageBlock getImageBlock(int row, int column) {
+        return blocks[row][column];
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageModeHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagehandler;
+
+import java.awt.*;
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+
+/**
+ * An ImageModeHandler abstracts the processing of an ImageInputStream based on the Nitf Image Mode.
+ * Pixel-by-pixel rendering is delegated to the supplied ImageRepresentationHandler.
+ */
+public interface ImageModeHandler {
+
+    /**
+     *
+     * @param imageSegmentHeader - the NitfImageSegmentHeader for the image being rendered.
+     * @param imageInputStream - the ImageInputStream containing the image data.
+     * @param targetImage - the Graphic2D that the image will be rendered to.
+     * @param imageRepresentationHandler - the ImageRepresentationHandler which will render a single pixel.
+     * @throws IOException - propagated from the ImageInputStream.
+     */
+    void handleImage(NitfImageSegmentHeader imageSegmentHeader, ImageInputStream imageInputStream,
+            Graphics2D targetImage, ImageRepresentationHandler imageRepresentationHandler)
+            throws IOException;
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagehandler/ImageRepresentationHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagehandler;
+
+/**
+ * An ImageRepresentationHandler calculates the values for a given pixel based on the current pixel value
+ * and the value of the band being read.  This interface abstracts the calculation of a single
+ * pixel value based on one or more band values for that pixel.
+ */
+
+@FunctionalInterface
+public interface ImageRepresentationHandler {
+    /**
+     * Applies the bandValue to currentValue based on bandIndex.
+     *
+     * @param currentValue - the current value for the pixel.
+     * @param bandValue - the value of the band being applied.
+     * @param bandIndex - the index of the band being applied, zero-indexed.
+     * @return - the new value for the current pixel.
+     */
+    int renderPixel(int currentValue, int bandValue, int bandIndex);
+}


### PR DESCRIPTION
This change adds support for RGB24:BANDSEQUENTIAL encoded images by adding a new layer of abstraction to the rendering library.
It introduces the concept of an ImageModeHandler, which encapsulates the algorithm necessary for parsing the image data while
delegating the creation of individual pixels to an ImageRepresentationHandler. Future refactoring changes will retrofit existing
imaging rending code into this pattern.