### PR TITLE
img-83 Test output shouldn't write to module folders.

### DIFF
--- a/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
+++ b/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
@@ -135,7 +135,7 @@ public class CgmParserTest {
     }
 
     private void testOneImage(String parentDirectory, String testfile) throws IOException {
-        String inputFileName = "/" + parentDirectory + "/" + testfile;
+        String inputFileName = File.separator + parentDirectory + File.separator + testfile;
         System.out.println("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
         try {
@@ -160,7 +160,7 @@ public class CgmParserTest {
             CgmRenderer renderer = new CgmRenderer();
             renderer.setTargetImageGraphics((Graphics2D) targetImage.getGraphics(), segment.getBoundingBox2Column(), segment.getBoundingBox2Row());
             renderer.render(parser.getCommandList());
-            File targetFile = new File(testfile + "cgm.png");
+            File targetFile = new File("target" + File.separator + testfile + "cgm.png");
             ImageIO.write(targetImage, "png", targetFile);
         } catch (ParseException e) {
             System.out.println("Failed to load from InputStream " + e.getMessage());

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
@@ -281,7 +281,7 @@ public class RenderJitcTest extends TestCase {
 
     private void testOneFile(final String testfile, final String parentDirectory)
             throws IOException, ParseException {
-        String inputFileName = "/" + parentDirectory + "/" + testfile;
+        String inputFileName = File.separator + parentDirectory + File.separator + testfile;
         System.out.println("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
 
@@ -296,7 +296,7 @@ public class RenderJitcTest extends TestCase {
 
                     try {
                         BufferedImage img = renderer.render(header, imageData);
-                        ImageIO.write(img, "png", new File(testfile + "_" + i.get() + ".png"));
+                        ImageIO.write(img, "png", new File("target" + File.separator + testfile + "_" + i.get() + ".png"));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
Modified the test classes so the output goes to the target/ folder.

@kcwire 
@bradh 