### PR TITLE
img-79 Replace all instances of System.out.println() with logging

### DIFF
--- a/cgm/src/main/java/org/codice/imaging/cgm/CgmIdentifier.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/CgmIdentifier.java
@@ -170,7 +170,7 @@ enum CgmIdentifier {
     SYMBOL_SIZE(CgmClass.ATTRIBUTE, 50, "SYMBOL SIZE"),
     SYMBOL_ORIENTATION(CgmClass.ATTRIBUTE, 51, "SYMBOL ORIENTATION");
 
-    private static final Logger LOG = LoggerFactory.getLogger(CgmIdentifier.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CgmIdentifier.class);
 
     private final CgmClass classId;
     private final int id;
@@ -187,13 +187,13 @@ enum CgmIdentifier {
     }
 
     static CgmIdentifier findIdentifier(final int elementClass, final int elementId) {
-        // System.out.println(String.format("Searching for for %d:%d", elementClass, elementId));
+        LOGGER.trace(String.format("Searching for %d:%d", elementClass, elementId));
         for (CgmIdentifier cgmIdentifier : values()) {
             if ((cgmIdentifier.classId.getClassIdentifier() == elementClass) && (cgmIdentifier.id == elementId)) {
                 return cgmIdentifier;
             }
         }
-        LOG.warn(String.format("Could not find identifier for %d:%d", elementClass, elementId));
+        LOGGER.warn(String.format("Could not find identifier for %d:%d", elementClass, elementId));
         return UNKNOWN;
     }
 

--- a/cgm/src/main/java/org/codice/imaging/cgm/CgmInputReader.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/CgmInputReader.java
@@ -35,6 +35,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper for CGM input data.
@@ -45,6 +47,7 @@ class CgmInputReader {
     private static final int NUM_BYTES_IN_SIGNED_VDC_INTEGER = 2;
     private static final int NUM_BYTES_IN_ENUM_VALUE = 2;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CgmInputReader.class);
     private final DataInputStream dataStream;
 
     CgmInputReader(final byte[] cgmData) {
@@ -73,7 +76,7 @@ class CgmInputReader {
     String getStringFixed() throws IOException {
         int count = dataStream.readUnsignedByte();
         if (count > LONG_COUNT_FLAG_VALUE) {
-            System.out.println("Need to handle long count");
+            LOGGER.info("Need to handle long count");
         }
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < count; ++i) {

--- a/cgm/src/main/java/org/codice/imaging/cgm/CgmParser.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/CgmParser.java
@@ -33,9 +33,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * CGM Parser.
@@ -55,10 +54,11 @@ public class CgmParser {
 
     private CgmInputReader dataReader = null;
     private final List<AbstractElement> commands = new ArrayList<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(CgmParser.class);
 
     private static AbstractElement getElement(final CgmIdentifier elementId) {
         if (ELEMENTS.containsKey(elementId)) {
-            // System.out.println("About to instantiate:" + elementId.getFriendlyName());
+            LOGGER.trace("About to instantiate:" + elementId.getFriendlyName());
             return instantiateElement(elementId);
         }
         return new NoArgumentsElement(CgmIdentifier.UNKNOWN);
@@ -83,7 +83,7 @@ public class CgmParser {
                  IllegalAccessException |
                  IllegalArgumentException |
                  InvocationTargetException ex) {
-            Logger.getLogger(CgmParser.class.getName()).log(Level.SEVERE, elementClass.getSimpleName(), ex);
+            LOGGER.error(ex.getMessage(), ex);
         }
         return null;
     }
@@ -93,7 +93,7 @@ public class CgmParser {
             Constructor<AbstractElement> constructor = elementClass.getDeclaredConstructor(CgmIdentifier.class);
             return constructor.newInstance(elementId);
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-            Logger.getLogger(CgmParser.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.error(ex.getMessage(), ex);
         }
         return null;
     }
@@ -318,7 +318,7 @@ public class CgmParser {
     }
 
     final void dump() {
-        System.out.print(getCommandListAsString());
+        LOGGER.debug(getCommandListAsString());
     }
 
     /**
@@ -350,7 +350,7 @@ public class CgmParser {
             int longFormWord2 = dataReader.readUnsignedShort();
             if ((longFormWord2 & NOT_LAST_PARTITION_FLAG_BIT) == NOT_LAST_PARTITION_FLAG_BIT) {
                 // Don't know how to handle this case yet
-                System.out.println("Not last partition");
+                LOGGER.info("Not last partition");
             }
             parameterListLength = longFormWord2 & LONG_FORM_WORD_LENGTH_BITMASK;
         }

--- a/cgm/src/main/java/org/codice/imaging/cgm/InteriorStyleElement.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/InteriorStyleElement.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  */
 class InteriorStyleElement extends ElementHelpers implements AbstractElement {
 
-    private static final Logger LOG = LoggerFactory.getLogger(InteriorStyleElement.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(InteriorStyleElement.class);
     private Mode mode = Mode.HOLLOW;
 
     private static final int STYLE_HOLLOW = 0;
@@ -87,7 +87,7 @@ class InteriorStyleElement extends ElementHelpers implements AbstractElement {
                 mode = Mode.INTERPOLATED;
                 break;
             default:
-                LOG.info("Unknown Interior Style value: " + data);
+                LOGGER.info("Unknown Interior Style value: " + data);
                 break;
         }
     }
@@ -101,10 +101,10 @@ class InteriorStyleElement extends ElementHelpers implements AbstractElement {
 
     @Override
     public void render(final Graphics2D g2, final CgmGraphicState graphicState) {
-        System.out.println("TODO: render for " + getFriendlyName());
+        LOGGER.debug("TODO: render for " + getFriendlyName());
         StringBuilder builder = new StringBuilder();
         addStringDescription(builder);
-        System.out.print(builder.toString());
+        LOGGER.debug(builder.toString());
     }
 
 }

--- a/cgm/src/main/java/org/codice/imaging/cgm/MarkerSizeSpecificationModeElement.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/MarkerSizeSpecificationModeElement.java
@@ -27,7 +27,11 @@ package org.codice.imaging.cgm;
 
 import java.awt.Graphics2D;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class MarkerSizeSpecificationModeElement extends CommonSpecificationModeElement {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MarkerSizeSpecificationModeElement.class);
 
     MarkerSizeSpecificationModeElement() {
         super(CgmIdentifier.MARKER_SIZE_SPECIFICATION_MODE);
@@ -35,7 +39,7 @@ class MarkerSizeSpecificationModeElement extends CommonSpecificationModeElement 
 
     @Override
     public void render(final Graphics2D g2, final CgmGraphicState graphicState) {
-        System.out.println("TODO: render for " + getFriendlyName());
+        LOGGER.info("TODO: render for " + getFriendlyName());
     }
 
 }

--- a/cgm/src/main/java/org/codice/imaging/cgm/NoArgumentsElement.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/NoArgumentsElement.java
@@ -28,7 +28,12 @@ package org.codice.imaging.cgm;
 import java.awt.Graphics2D;
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class NoArgumentsElement extends ElementHelpers implements AbstractElement {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoArgumentsElement.class);
 
     NoArgumentsElement(final CgmIdentifier cgmIdentifier) {
         super(cgmIdentifier);
@@ -37,7 +42,7 @@ class NoArgumentsElement extends ElementHelpers implements AbstractElement {
     @Override
     public void readParameters(final CgmInputReader dataReader, final int parameterListLength) throws IOException {
         if (parameterListLength != 0) {
-            System.out.println("****Need to convert");
+            LOGGER.debug("****Need to convert");
             dataReader.skipBytes(parameterListLength);
         }
     }

--- a/cgm/src/main/java/org/codice/imaging/cgm/PolygonSetElement.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/PolygonSetElement.java
@@ -32,8 +32,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class PolygonSetElement extends ElementHelpers {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PolygonSetElement.class);
+
     private final List<Point> points = new ArrayList<>();
     private final List<Integer> edgeOutFlags = new ArrayList<>();
 
@@ -68,7 +72,7 @@ class PolygonSetElement extends ElementHelpers {
 
     @Override
     public void render(final Graphics2D g2, final CgmGraphicState graphicState) {
-        System.out.println("figure out how to render edge out flags");
+        LOGGER.debug("figure out how to render edge out flags");
         applyFilledPrimitiveAttributes(g2, graphicState);
         Polygon polygon = new Polygon();
         for (int pointIndex = 0; pointIndex < points.size(); ++pointIndex) {

--- a/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
+++ b/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
@@ -46,11 +46,14 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 public class CgmParserTest {
+    private final Logger LOGGER = LoggerFactory.getLogger(CgmParserTest.class);
 
     public CgmParserTest() {
     }
@@ -136,16 +139,16 @@ public class CgmParserTest {
 
     private void testOneImage(String parentDirectory, String testfile) throws IOException {
         String inputFileName = File.separator + parentDirectory + File.separator + testfile;
-        System.out.println("================================== Testing :" + inputFileName);
+        LOGGER.info("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
         try {
-            System.out.println("loading from InputStream");
+            LOGGER.info("loading from InputStream");
             NitfReader reader = new NitfInputStreamReader(new BufferedInputStream(getClass().getResourceAsStream(inputFileName)));
             AllDataExtractionParseStrategy parseStrategy = new AllDataExtractionParseStrategy();
             NitfFileParser.parse(reader, parseStrategy);
 
             if (parseStrategy.getGraphicSegmentHeaders().isEmpty()) {
-                System.out.println("Loaded file, but found no graphic segments.");
+                LOGGER.info("Loaded file, but found no graphic segments.");
                 System.exit(0);
             }
             NitfGraphicSegmentHeader segment = parseStrategy.getGraphicSegmentHeaders().get(0);
@@ -163,8 +166,7 @@ public class CgmParserTest {
             File targetFile = new File("target" + File.separator + testfile + "cgm.png");
             ImageIO.write(targetImage, "png", targetFile);
         } catch (ParseException e) {
-            System.out.println("Failed to load from InputStream " + e.getMessage());
-            e.printStackTrace();
+            LOGGER.error("Failed to load from InputStream " + e.getMessage());
         }
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/SlottedNitfParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/SlottedNitfParseStrategy.java
@@ -17,7 +17,9 @@ package org.codice.imaging.nitf.core;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.transform.Source;
+
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfReader;
@@ -35,6 +37,8 @@ import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.codice.imaging.nitf.core.text.TextSegmentHeaderParser;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreCollectionParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * "Slotted" parse strategy.
@@ -44,6 +48,8 @@ import org.codice.imaging.nitf.core.tre.TreCollectionParser;
  * the abstract subclass with the data storage (SlottedStorageNitfParseStrategy)
  */
 public abstract class SlottedNitfParseStrategy implements NitfParseStrategy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SlottedNitfParseStrategy.class);
+
     /**
      * The file level header.
      */
@@ -198,7 +204,7 @@ public abstract class SlottedNitfParseStrategy implements NitfParseStrategy {
                 handleDataExtensionSegment(reader, i);
             }
         } catch (ParseException ex) {
-            System.out.println("Exception should be logged: " + ex);
+            LOGGER.error(ex.getMessage() + ex);
         }
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractNitfSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractNitfSegmentParser.java
@@ -14,10 +14,12 @@
  */
 package org.codice.imaging.nitf.core.common;
 
-import java.text.ParseException;
-import org.codice.imaging.nitf.core.RGBColour;
 import static org.codice.imaging.nitf.core.common.CommonConstants.ENCRYP_LENGTH;
 import static org.codice.imaging.nitf.core.common.CommonConstants.RGB_COLOUR_LENGTH;
+
+import java.text.ParseException;
+
+import org.codice.imaging.nitf.core.RGBColour;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,13 +64,9 @@ public abstract class AbstractNitfSegmentParser {
     }
 
     /**
-<<<<<<< HEAD
      * Read in a NITF date/time format.
      *
      * Note that this is relatively tolerant, and may not result in something usable as a date/time class in Java.
-=======
-     * Read in a NitfDateTime from the current reader position.
->>>>>>> [IMG-75] Be more tolerant of incomplete / empty date fields,
      *
      * @return a NitfDateTime from head of the reader stream.
      * @throws ParseException when the next token is not the expected format for a NitfDateTime.

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/RasterProductFormatAttributeParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/RasterProductFormatAttributeParser.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 */
 public class RasterProductFormatAttributeParser {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RasterProductFormatAttributeParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RasterProductFormatAttributeParser.class);
 
     private static final int ATTRIBUTE_SECTION_SUBHEADER_LENGTH = 10;
 
@@ -152,7 +152,7 @@ public class RasterProductFormatAttributeParser {
                 case CONTOUR_INTERVAL_ATTR_ID:
                     break;
                 default:
-                    System.out.println(String.format("Unhandled offset record: %d/%d - %d", offsetRecord.attributeId, offsetRecord.parameterId,
+                    LOGGER.info(String.format("Unhandled offset record: %d/%d - %d", offsetRecord.attributeId, offsetRecord.parameterId,
                     offsetRecord.arealCoverageSequenceNumber));
                     break;
             }
@@ -188,7 +188,7 @@ public class RasterProductFormatAttributeParser {
         try {
             return new String(data, "US-ASCII");
         } catch (UnsupportedEncodingException ex) {
-            LOG.warn("UnsupportedEncodingException while trying to convert to ASCII:", ex);
+            LOGGER.error("UnsupportedEncodingException while trying to convert to ASCII:", ex);
         }
         return "";
     }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -14,6 +14,12 @@
  **/
 package org.codice.imaging.nitf.core;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -25,7 +31,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.xml.transform.stream.StreamSource;
+
 import org.codice.imaging.nitf.core.common.FileReader;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
@@ -52,24 +60,20 @@ import org.codice.imaging.nitf.core.text.TextSegmentHeader;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreEntry;
-import static org.hamcrest.Matchers.is;
 import org.junit.After;
 import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
 import uk.org.lidalia.slf4jtest.LoggingEvent;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class Nitf21HeaderTest {
 
-    TestLogger logger = TestLoggerFactory.getTestLogger(TreEntry.class);
+    TestLogger LOGGER = TestLoggerFactory.getTestLogger(TreEntry.class);
 
     private DateTimeFormatter formatter = null;
 
@@ -785,7 +789,7 @@ public class Nitf21HeaderTest {
         assertEquals(4, tres.getTREs().size());
         Tre lastTre = tres.getTREs().get(3);
         lastTre.dump();
-        assertThat(logger.getLoggingEvents(), is(Arrays.asList(
+        assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
             LoggingEvent.debug("\tName: LASTNME"),
             LoggingEvent.debug("\tValue: WEBB                        "),
             LoggingEvent.debug("\tName: FIRSTNME"),

--- a/core/src/test/java/org/codice/imaging/nitf/core/common/AbstractParserTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/common/AbstractParserTest.java
@@ -14,11 +14,15 @@
  **/
 package org.codice.imaging.nitf.core.common;
 
+import static org.hamcrest.Matchers.is;
+
+import static org.junit.Assert.assertThat;
+
 import java.text.ParseException;
 import java.util.Arrays;
-import static org.hamcrest.Matchers.is;
+
 import org.junit.After;
-import static org.junit.Assert.assertThat;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,8 +34,9 @@ import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
 public class AbstractParserTest {
+    private static final int STANDARD_DATE_TIME_LENGTH = 14;
 
-    TestLogger logger = TestLoggerFactory.getTestLogger(AbstractNitfSegmentParser.class);
+    private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(AbstractNitfSegmentParser.class);
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -44,7 +49,7 @@ public class AbstractParserTest {
         parser.reader = mockReader;
         when(mockReader.readBytes(1)).thenReturn("0");
         parser.readENCRYP();
-        assertThat(logger.getLoggingEvents().isEmpty(), is(true));
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
 
         try {
             when(mockReader.readBytes(1)).thenReturn("1");
@@ -52,7 +57,7 @@ public class AbstractParserTest {
             exception.expectMessage("Unexpected ENCRYP value");
             parser.readENCRYP();
         } finally {
-            assertThat(logger.getLoggingEvents(), is(Arrays.asList(LoggingEvent.warn("Mismatch while reading ENCRYP"))));
+            assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(LoggingEvent.warn("Mismatch while reading ENCRYP"))));
         }
     }
 

--- a/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparison.java
+++ b/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparison.java
@@ -16,19 +16,23 @@ package org.codice.nitf.metadatacomparison;
 
 import java.io.File;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class FileComparison {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileComparison.class);
 
     private FileComparison() {
     }
 
     public static void main( String[] args ) {
         if (args.length == 0) {
-            System.out.println("No file provided, not comparing");
+            LOGGER.error("No file provided, not comparing");
             return;
         }
         for (String arg : args) {
             if (new File(arg).isDirectory()) {
-                System.out.println("Walking contents of " + arg);
+                LOGGER.info("Walking contents of " + arg);
                 File[] files = new File(arg).listFiles();
                 for (File file : files) {
                     handleFile(arg + "/" + file.getName());
@@ -41,7 +45,7 @@ public class FileComparison {
 
     private static void handleFile(String filename) {
         if (new File(filename).isFile() && (! filename.endsWith(".txt"))) {
-            System.out.println("Dumping output of " + filename);
+            LOGGER.info("Dumping output of " + filename);
             compareOneFile(filename);
         }
     }

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfDataObject.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfDataObject.java
@@ -17,9 +17,10 @@ package org.codice.imaging.nitf.nitfnetbeansfiletype;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
-import org.codice.imaging.nitf.core.common.FileReader;
+
 import org.codice.imaging.nitf.core.NitfFileHeader;
 import org.codice.imaging.nitf.core.NitfFileParser;
+import org.codice.imaging.nitf.core.common.FileReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -32,6 +33,8 @@ import org.openide.loaders.MultiFileLoader;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.NbBundle.Messages;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Messages({
     "LBL_Nitf_LOADER=Files of NitfFileHeader"
@@ -103,6 +106,7 @@ import org.openide.util.NbBundle.Messages;
 // CSON: MagicNumber
 class NitfDataObject extends MultiDataObject {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(MultiDataObject.class);
     private DeferredSegmentParseStrategy parseStrategy;
 
     public NitfDataObject(final FileObject pf, final MultiFileLoader loader) throws IOException {
@@ -115,7 +119,7 @@ class NitfDataObject extends MultiDataObject {
             parseStrategy = new DeferredSegmentParseStrategy();
             NitfFileParser.parse(reader, parseStrategy);
         } catch (ParseException e) {
-            System.out.println("NitfDataObject Exception:" + e);
+            LOGGER.error("NitfDataObject Exception:", e);
             throw new IOException(e);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -34,4 +34,12 @@
         </repository>
     </distributionManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.14</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
@@ -20,8 +20,11 @@ import java.util.List;
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ImageMask {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageMask.class);
 
     private NitfImageSegmentHeader mImageSegmentHeader = null;
 
@@ -73,19 +76,19 @@ public final class ImageMask {
         int bmrlnth = imageInputStream.readShort();
         int tmrlnth = imageInputStream.readShort();
         int tpxcdlnth = imageInputStream.readShort();
-        System.out.println(String.format("Blocked image data offset: 0x%08x", imdatoff));
-        System.out.println(String.format("Block mask record length: 0x%04x", bmrlnth));
-        System.out.println(String.format("Pad Pixel Mask Record Length: 0x%04x", tmrlnth));
-        System.out.println(String.format("Pad Output pixel code length: 0x%04x", tpxcdlnth));
+        LOGGER.debug(String.format("Blocked image data offset: 0x%08x", imdatoff));
+        LOGGER.debug(String.format("Block mask record length: 0x%04x", bmrlnth));
+        LOGGER.debug(String.format("Pad Pixel Mask Record Length: 0x%04x", tmrlnth));
+        LOGGER.debug(String.format("Pad Output pixel code length: 0x%04x", tpxcdlnth));
         if (tpxcdlnth > 0) {
             tpxcd = 0;
             int numBytesToRead = (tpxcdlnth + 7) / 8;
-            System.out.println("Reading TPXCD at length:" + numBytesToRead);
+            LOGGER.debug("Reading TPXCD at length:" + numBytesToRead);
             int bandBits = (int)imageInputStream.readBits(numBytesToRead * 8);
             for (int i = 0; i < mImageSegmentHeader.getNumBands(); ++i) {
                 tpxcd = tpxcd | (bandBits << (8*i));
             }
-            System.out.println(String.format("Pad Output pixel code : 0x%08x", tpxcd));
+            LOGGER.debug(String.format("Pad Output pixel code : 0x%08x", tpxcd));
         }
         int numBandsToRead = 1;
         if (mImageSegmentHeader.getImageMode() == ImageMode.BANDSEQUENTIAL) {
@@ -96,7 +99,7 @@ public final class ImageMask {
             for (int m = 0; m < numBandsToRead; ++m) {
                 for (int n = 0; n < mImageSegmentHeader.getNumberOfBlocksPerRow() * mImageSegmentHeader.getNumberOfBlocksPerColumn(); ++n) {
                     bmrnbndm[n][m] = imageInputStream.readInt();
-                    System.out.println(String.format("mask blocks (band %d) %d: 0x%08x", m, n, bmrnbndm[n][m]));
+                    LOGGER.debug(String.format("mask blocks (band %d) %d: 0x%08x", m, n, bmrnbndm[n][m]));
                 }
             }
         }
@@ -105,7 +108,7 @@ public final class ImageMask {
                 for (int n = 0; n < mImageSegmentHeader.getNumberOfBlocksPerRow() * mImageSegmentHeader.getNumberOfBlocksPerColumn(); ++n) {
                     int val = imageInputStream.readInt();
                     tmrnbndm.add(val);
-                    System.out.println(String.format("mask pixel (band %d) %d: 0x%08x", m, n, val));
+                    LOGGER.debug(String.format("mask pixel (band %d) %d: 0x%08x", m, n, val));
                 }
             }
         }

--- a/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/UncompressedBlockRenderer.java
@@ -21,15 +21,20 @@ import java.awt.image.DataBufferUShort;
 import java.awt.image.IndexColorModel;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
+
 import javax.imageio.stream.ImageInputStream;
+
 import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.NitfImageBand;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
 import org.codice.imaging.nitf.core.image.PixelJustification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class UncompressedBlockRenderer implements BlockRenderer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(UncompressedBlockRenderer.class);
     private NitfImageSegmentHeader mImageSegmentHeader = null;
     private ImageInputStream mImageData = null;
     private ImageMask mMask = null;
@@ -68,8 +73,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
             case MULTIBAND:
                 return getNextImageBlockMultiband();
             default:
-                System.out.println("Unhandled image representation:" + mImageSegmentHeader.getImageRepresentation());
-                return null;
+                throw new UnsupportedOperationException("Unhandled image representation:" + mImageSegmentHeader.getImageRepresentation());
         }
     }
 
@@ -81,8 +85,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
 
     private BufferedImage getNextImageBlockMono() throws IOException {
         if ((mImageSegmentHeader.getImageMode() != ImageMode.BLOCKINTERLEVE) || (mImageSegmentHeader.getNumBands() != 1)) {
-            System.out.println("Unsupported mode / band combination: " + mImageSegmentHeader.getImageMode() + ", " + mImageSegmentHeader.getNumBands());
-            return null;
+            throw new UnsupportedOperationException("Unsupported mode / band combination: " + mImageSegmentHeader.getImageMode() + ", " + mImageSegmentHeader.getNumBands());
         }
         // TODO: masked image
         switch (mImageSegmentHeader.getNumberOfBitsPerPixelPerBand()) {
@@ -96,15 +99,13 @@ class UncompressedBlockRenderer implements BlockRenderer {
                 if (mImageSegmentHeader.getNumberOfBitsPerPixelPerBand() < 16) {
                     return getNextImageBlockMonoArbitrary();
                 } else {
-                    System.out.println("Unhandled Mono bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
+                    throw new UnsupportedOperationException("Unhandled Mono bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
                 }
-                return null;
         }
     }
     private BufferedImage getNextImageBlockRGBLUT() throws IOException {
         if ((mImageSegmentHeader.getImageMode() != ImageMode.BLOCKINTERLEVE) || (mImageSegmentHeader.getNumBands() != 1)) {
-            System.out.println("Unsupported mode / band combination: " + mImageSegmentHeader.getImageMode() + ", " + mImageSegmentHeader.getNumBands());
-            return null;
+            throw new UnsupportedOperationException("Unsupported mode / band combination: " + mImageSegmentHeader.getImageMode() + ", " + mImageSegmentHeader.getNumBands());
         }
         // TODO: masked image
         switch (mImageSegmentHeader.getNumberOfBitsPerPixelPerBand()) {
@@ -113,8 +114,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
             case 8:
                 return getNextImageBlockRGBLUT8();
             default:
-                System.out.println("Unhandled RGBLUT bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
-                return null;
+                throw new UnsupportedOperationException("Unhandled RGBLUT bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
         }
     }
 
@@ -122,8 +122,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
         if (mImageSegmentHeader.getActualBitsPerPixelPerBand() == 8) {
             return getNextImageBlockRGB24();
         } else {
-            System.out.println("Unhandled RGBTRUECOLOUR bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
-            return null;
+            throw new UnsupportedOperationException("Unhandled RGBTRUECOLOUR bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
         }
     }
 
@@ -131,8 +130,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
         if (mImageSegmentHeader.getActualBitsPerPixelPerBand() == 8) {
             return getNextImageBlockMultiband8();
         } else {
-            System.out.println("Unhandled MULTIBAND bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
-            return null;
+            throw new UnsupportedOperationException("Unhandled MULTIBAND bit depth:" + mImageSegmentHeader.getNumberOfBitsPerPixelPerBand());
         }
     }
 
@@ -231,7 +229,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
                 }
             }
         } else {
-            System.out.println("Unhandled image mode for RGB24:" + mImageSegmentHeader.getImageMode());
+            throw new UnsupportedOperationException("Unhandled image mode for RGB24:" + mImageSegmentHeader.getImageMode());
         }
 
         int[] imgData = ((DataBufferInt)img.getRaster().getDataBuffer()).getData();
@@ -314,8 +312,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
                             mImageData.read();
                             break;
                         default:
-                            System.out.println("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
-                            break;
+                            throw new UnsupportedOperationException("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
                     }
                 }
                 if ((mMask == null) || (!mMask.isPadPixel(data[i]))) {
@@ -346,8 +343,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
                             mImageData.skipBytes(mImageSegmentHeader.getNumberOfPixelsPerBlockHorizontal());
                             break;
                         default:
-                            System.out.println("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
-                            break;
+                            throw new UnsupportedOperationException("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
                     }
 
                 }
@@ -389,8 +385,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
                         mImageData.skipBytes(mImageSegmentHeader.getNumberOfPixelsPerBlockHorizontal() * mImageSegmentHeader.getNumberOfPixelsPerBlockVertical());
                         break;
                     default:
-                        System.out.println("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
-                        break;
+                        throw new UnsupportedOperationException("unhandled image representation: " + mImageSegmentHeader.getImageBandZeroBase(bandIndex).getImageRepresentation());
                     }
                 }
             for (int row = 0; row < mImageSegmentHeader.getNumberOfPixelsPerBlockVertical(); ++row) {
@@ -402,7 +397,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
                 }
             }
         } else {
-            System.out.println("Unhandled image mode for MULTIBAND:" + mImageSegmentHeader.getImageMode());
+            throw new UnsupportedOperationException("Unhandled image mode for MULTIBAND:" + mImageSegmentHeader.getImageMode());
         }
         int[] imgData = ((DataBufferInt)img.getRaster().getDataBuffer()).getData();
         System.arraycopy(data, 0, imgData, 0, data.length);
@@ -413,7 +408,7 @@ class UncompressedBlockRenderer implements BlockRenderer {
         // TODO: this should handle mask blocks.
         int numberOfBlocks = rowIndex * mImageSegmentHeader.getNumberOfBlocksPerRow() + columnIndex;
         if (mMask.isMaskedBlock(numberOfBlocks, 0)) {
-            System.out.println("Some masked block");
+            LOGGER.debug("Some masked block");
         }
         return numberOfBlocks * mImageSegmentHeader.getNumberOfBytesPerBlock();
     }

--- a/render/src/main/java/org/codice/imaging/nitf/render/VectorQuantizationBlockRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/VectorQuantizationBlockRenderer.java
@@ -14,22 +14,24 @@
  */
 package org.codice.imaging.nitf.render;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import java.awt.image.BufferedImage;
 import java.awt.image.IndexColorModel;
 import java.awt.image.WritableRaster;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.imageio.stream.ImageInputStream;
 
 import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.NitfImageSegmentHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class VectorQuantizationBlockRenderer implements BlockRenderer {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(VectorQuantizationBlockRenderer.class);
     private NitfImageSegmentHeader mImageSegment = null;
     private ImageInputStream mImageData = null;
     private ImageMask mMask = null;
@@ -82,12 +84,11 @@ class VectorQuantizationBlockRenderer implements BlockRenderer {
                 }
                 return getNextImageBlockRgbLut8();
             } else {
-                System.out.println("Unhandled image representation:" + mImageSegment.getImageRepresentation());
+                throw new UnsupportedOperationException("Unhandled image representation:" + mImageSegment.getImageRepresentation());
             }
         } else {
-            System.out.println("Unhandled ActualBitsPerPixelPerBand: " + mImageSegment.getActualBitsPerPixelPerBand());
+            throw new UnsupportedOperationException("Unhandled ActualBitsPerPixelPerBand: " + mImageSegment.getActualBitsPerPixelPerBand());
         }
-        return null;
     }
 
     @Override
@@ -138,11 +139,11 @@ class VectorQuantizationBlockRenderer implements BlockRenderer {
 
     private final void readImageDisplayParameterSubheader() throws IOException {
         mNumberOfImageRows = mImageData.readInt();
-        // System.out.println("mNumberOfImageRows:" + mNumberOfImageRows);
+        LOGGER.debug("mNumberOfImageRows:" + mNumberOfImageRows);
         mNumberOfImageCodesPerRow = mImageData.readInt();
-        // System.out.println("mNumberOfImageCodesPerRow: " + mNumberOfImageCodesPerRow);
+        LOGGER.debug("mNumberOfImageCodesPerRow: " + mNumberOfImageCodesPerRow);
         mImageCodeBitLength = mImageData.readUnsignedByte();
-        // System.out.println("mImageCodeBitLength:" + mImageCodeBitLength);
+        LOGGER.debug("mImageCodeBitLength:" + mImageCodeBitLength);
     }
 
     private final void readCompressionSection() throws IOException {
@@ -152,18 +153,18 @@ class VectorQuantizationBlockRenderer implements BlockRenderer {
 
     private final void readCompressionSectionSubheader() throws IOException {
         mCompressionAlgorithmId = mImageData.readUnsignedShort();
-        // System.out.println("mCompressionAlgorithmId:" + mCompressionAlgorithmId);
+        LOGGER.debug("mCompressionAlgorithmId:" + mCompressionAlgorithmId);
         mNumberOfCompressionLookupOffsetRecords = mImageData.readUnsignedShort();
-        // System.out.println("mNumberOfCompressionLookupOffsetRecords:" + mNumberOfCompressionLookupOffsetRecords);
+        LOGGER.debug("mNumberOfCompressionLookupOffsetRecords:" + mNumberOfCompressionLookupOffsetRecords);
         mNumberOfCompressionParameterOffsetRecords = mImageData.readUnsignedShort();
-        // System.out.println("mNumberOfCompressionParameterOffsetRecords:" + mNumberOfCompressionParameterOffsetRecords);
+        LOGGER.debug("mNumberOfCompressionParameterOffsetRecords:" + mNumberOfCompressionParameterOffsetRecords);
     }
 
     private final void readCompressionLookupSubsection() throws IOException {
         mCompressionLookupOffsetTableOffset = mImageData.readInt();
-        // System.out.println("mCompressionLookupOffsetTableOffset:" + mCompressionLookupOffsetTableOffset);
+        LOGGER.debug("mCompressionLookupOffsetTableOffset:" + mCompressionLookupOffsetTableOffset);
         mCompressionLookupTableOffsetRecordLength = mImageData.readUnsignedShort();
-        // System.out.println("mCompressionLookupTableOffsetRecordLength:" + mCompressionLookupTableOffsetRecordLength);
+        LOGGER.debug("mCompressionLookupTableOffsetRecordLength:" + mCompressionLookupTableOffsetRecordLength);
         readCompressionLookupOffsetTable();
         readCompressionLookupTables();
     }
@@ -173,16 +174,16 @@ class VectorQuantizationBlockRenderer implements BlockRenderer {
     }
 
     private final void readCompressionLookupOffsetRecords() throws IOException {
-        // System.out.println("mNumberOfCompressionLookupOffsetRecords:" + mNumberOfCompressionLookupOffsetRecords);
+        LOGGER.debug("mNumberOfCompressionLookupOffsetRecords:" + mNumberOfCompressionLookupOffsetRecords);
         for (int i = 0; i < mNumberOfCompressionLookupOffsetRecords; ++i) {
             VQCompressionLookupOffsetRecord record = new VQCompressionLookupOffsetRecord();
             record.compressionLookupTableId = mImageData.readUnsignedShort();
             record.numberOfCompressionLookupRecords = mImageData.readInt();
-            // System.out.println("numberOfCompressionLookupRecords:" + record.numberOfCompressionLookupRecords);
+            LOGGER.debug("numberOfCompressionLookupRecords:" + record.numberOfCompressionLookupRecords);
             record.numberOfValuesPerCompressionLookupRecord = mImageData.readUnsignedShort();
-            // System.out.println("numberOfValuesPerCompressionLookupRecord:" + record.numberOfValuesPerCompressionLookupRecord);
+            LOGGER.debug("numberOfValuesPerCompressionLookupRecord:" + record.numberOfValuesPerCompressionLookupRecord);
             record.compressionLookupValueBitLength = mImageData.readUnsignedShort();
-            // System.out.println("compressionLookupValueBitLength:" + record.compressionLookupValueBitLength);
+            LOGGER.debug("compressionLookupValueBitLength:" + record.compressionLookupValueBitLength);
             record.compressionLookupTableOffset = mImageData.readInt();
             mCompressionLookupOffsetRecords.add(record);
         }

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/package-info.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/package-info.java
@@ -26,7 +26,7 @@
  *   new NitfParserInputFlow()
  *       .inputStream(getImageInputStream())
  *       .allData()
- *       .fileHeader(header -> System.out.println(header.getIdentifier())
+ *       .fileHeader(header -> LOGGER.debug(header.getIdentifier())
  *       .forEachImage((header, imageInputStream) -> renderImage(header, imageInputStream);
  * }
  * </pre>

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
@@ -22,9 +22,14 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+
 import javax.imageio.ImageIO;
+
 import org.codice.imaging.nitf.render.flow.NitfParserInputFlow;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import junit.framework.TestCase;
 
 /**
@@ -34,6 +39,8 @@ import junit.framework.TestCase;
  * http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/scen_2_1.html
  */
 public class RenderJitcTest extends TestCase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RenderJitcTest.class);
 
     public RenderJitcTest(String testName) {
         super(testName);
@@ -282,7 +289,7 @@ public class RenderJitcTest extends TestCase {
     private void testOneFile(final String testfile, final String parentDirectory)
             throws IOException, ParseException {
         String inputFileName = File.separator + parentDirectory + File.separator + testfile;
-        System.out.println("================================== Testing :" + inputFileName);
+        LOGGER.info("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
 
         final ThreadLocal<Integer> i = new ThreadLocal<Integer>();
@@ -297,8 +304,8 @@ public class RenderJitcTest extends TestCase {
                     try {
                         BufferedImage img = renderer.render(header, imageData);
                         ImageIO.write(img, "png", new File("target" + File.separator + testfile + "_" + i.get() + ".png"));
-                    } catch (IOException e) {
-                        e.printStackTrace();
+                    } catch (IOException|UnsupportedOperationException e) {
+                        LOGGER.error(e.getMessage(), e);
                     }
 
                     i.set(i.get() + 1);


### PR DESCRIPTION
Replaced calls to System.out.println() and Exception.printStackTrace() with logging statements.

@bradh 
@kcwire 