### PR TITLE
[IMG-89] Implement image handler for Pixel, Row and Block Interleve.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -26,7 +26,10 @@ import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.imagemode.BandSequentialImageModeHandler;
+import org.codice.imaging.nitf.render.imagemode.BlockInterleveImageModeHandler;
 import org.codice.imaging.nitf.render.imagemode.ImageModeHandler;
+import org.codice.imaging.nitf.render.imagemode.PixelInterleveImageModeHandler;
+import org.codice.imaging.nitf.render.imagemode.RowInterleveImageModeHandler;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandlerFactory;
 
@@ -39,6 +42,9 @@ public class NitfRenderer {
 
     static {
         IMAGE_MODE_HANDLER_MAP.put(ImageMode.BANDSEQUENTIAL, new BandSequentialImageModeHandler());
+        IMAGE_MODE_HANDLER_MAP.put(ImageMode.PIXELINTERLEVE, new PixelInterleveImageModeHandler());
+        IMAGE_MODE_HANDLER_MAP.put(ImageMode.ROWINTERLEVE, new RowInterleveImageModeHandler());
+        IMAGE_MODE_HANDLER_MAP.put(ImageMode.BLOCKINTERLEVE, new BlockInterleveImageModeHandler());
     }
 
     /**

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagemode;
+
+import java.awt.image.DataBuffer;
+import java.io.IOException;
+import javax.imageio.stream.ImageInputStream;
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
+
+/**
+ * ImageModeHandler for Block Interleve mode.
+ */
+public class BlockInterleveImageModeHandler extends SharedImageModeHandler implements ImageModeHandler {
+
+    @Override
+    protected ImageMode getSupportedImageMode() {
+        return ImageMode.BLOCKINTERLEVE;
+    }
+
+
+    @Override
+    protected String getHandlerName() {
+        return "BlockInterleveImageModeHandler";
+    }
+
+    @Override
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+
+        final DataBuffer data = block.getDataBuffer();
+        ImageInputStream imageInputStream = imageSegment.getData();
+
+        try {
+            for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
+                for (int row = 0; row < block.getHeight(); row++) {
+                    for (int column = 0; column < block.getWidth(); column++) {
+                        int i = row * block.getWidth() + column;
+                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagemode;
+
+import java.awt.image.DataBuffer;
+import java.io.IOException;
+import javax.imageio.stream.ImageInputStream;
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
+
+/**
+ * ImageModeHandler for Pixel Interleve mode.
+ */
+public class PixelInterleveImageModeHandler extends SharedImageModeHandler implements ImageModeHandler {
+
+    @Override
+    protected String getHandlerName() {
+        return "PixelInterleveImageModeHandler";
+    }
+
+    @Override
+    protected ImageMode getSupportedImageMode() {
+        return ImageMode.PIXELINTERLEVE;
+    }
+
+    @Override
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+
+        final DataBuffer data = block.getDataBuffer();
+        ImageInputStream imageInputStream = imageSegment.getData();
+
+        try {
+            for (int row = 0; row < block.getHeight(); row++) {
+                for (int column = 0; column < block.getWidth(); column++) {
+                    for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
+                        int i = row * block.getWidth() + column;
+                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagemode;
+
+import java.awt.image.DataBuffer;
+import java.io.IOException;
+import javax.imageio.stream.ImageInputStream;
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
+
+/**
+ * ImageModeHandler for Row Interleve mode.
+ */
+public class RowInterleveImageModeHandler extends SharedImageModeHandler implements ImageModeHandler {
+
+    @Override
+    protected ImageMode getSupportedImageMode() {
+        return ImageMode.ROWINTERLEVE;
+    }
+
+
+    @Override
+    protected String getHandlerName() {
+        return "RowInterleveImageModeHandler";
+    }
+
+    @Override
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+
+        final DataBuffer data = block.getDataBuffer();
+        ImageInputStream imageInputStream = imageSegment.getData();
+
+        try {
+            for (int row = 0; row < block.getHeight(); row++) {
+                for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
+                    for (int column = 0; column < block.getWidth(); column++) {
+                        int i = row * block.getWidth() + column;
+                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
@@ -12,34 +12,30 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-
 package org.codice.imaging.nitf.render.imagemode;
 
 import java.awt.Graphics2D;
-import java.awt.image.DataBuffer;
 import java.io.IOException;
-import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.ImageMask;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
 
-public class BandSequentialImageModeHandler implements ImageModeHandler {
-    private static final String NULL_ARG_ERROR_MESSAGE =
-            "BandSequentialImageModeHandler(): argument '%s' may not be null.";
+/**
+ * A shared implementation of the various ImageModeHandler cases.
+ */
+abstract class SharedImageModeHandler implements ImageModeHandler {
+    protected static final String NULL_ARG_ERROR_MESSAGE = "%s: argument '%s' may not be null.";
 
     /**
-     *
      * {@inheritDoc}
      */
     @Override
     public void handleImage(ImageSegment imageSegment, Graphics2D targetImage,
             ImageRepresentationHandler imageRepresentationHandler) throws IOException {
 
-        checkNull(imageSegment, "imageSegment");
-        checkNull(targetImage, "targetImage");
-        checkNull(imageRepresentationHandler, "imageRepresentationHandler");
+        nullCheckArguments(imageSegment, targetImage, imageRepresentationHandler);
 
         ImageMask iMask = null;
 
@@ -51,56 +47,52 @@ public class BandSequentialImageModeHandler implements ImageModeHandler {
 
         final ImageMask imageMask = iMask;
 
-        if (!ImageMode.BANDSEQUENTIAL.equals(imageSegment.getImageMode())) {
-            throw new IllegalStateException(
-                "BandSequentialImageModeHandler(): argument 'imageSegment' must have be ImageMode of 'S'.");
-        }
+        checkImageMode(imageSegment);
 
         ImageBlockMatrix matrix = new ImageBlockMatrix(imageSegment,
                 () -> imageRepresentationHandler.createBufferedImage(imageSegment.getNumberOfPixelsPerBlockHorizontal(),
                         imageSegment.getNumberOfPixelsPerBlockVertical()));
 
-        for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
-            final int index = bandIndex;
-
-            matrix.forEachBlock(block -> {
-                readBlock(block, imageSegment.getData(), imageRepresentationHandler, index);
-                applyMask(block, imageMask, imageRepresentationHandler);
-            } );
-        }
+        matrix.forEachBlock(block -> {
+            readBlock(block, imageSegment, imageRepresentationHandler);
+            applyMask(block, imageMask, imageRepresentationHandler);
+        });
 
         matrix.forEachBlock((block) -> block.render(targetImage, true));
     }
 
+    protected abstract String getHandlerName();
+
+    protected abstract ImageMode getSupportedImageMode();
+
+    protected abstract void readBlock(ImageBlock block, ImageSegment imageSegment,
+            ImageRepresentationHandler imageRepresentationHandler);
+
+    private void nullCheckArguments(ImageSegment imageSegment, Graphics2D targetImage,
+            ImageRepresentationHandler imageRepresentationHandler) {
+        checkNull(imageSegment, "imageSegment");
+        checkNull(targetImage, "targetImage");
+        checkNull(imageRepresentationHandler, "imageRepresentationHandler");
+    }
+
     private void checkNull(Object value, String valueName) {
         if (value == null) {
-            throw new IllegalArgumentException(String.format(NULL_ARG_ERROR_MESSAGE, valueName));
+            throw new IllegalArgumentException(String.format(NULL_ARG_ERROR_MESSAGE, getHandlerName(), valueName));
         }
     }
 
-    private void readBlock(ImageBlock block, ImageInputStream imageInputStream,
-            ImageRepresentationHandler imageRepresentationHandler, int bandIndex) {
-
-        final DataBuffer data = block.getDataBuffer();
-
-        try {
-            for (int row = 0; row < block.getHeight(); row++) {
-                for (int column = 0; column < block.getWidth(); column++) {
-                    int i = row * block.getWidth() + column;
-                    imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
-                }
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    private void checkImageMode(ImageSegment imageSegment) throws IllegalStateException {
+        if (!getSupportedImageMode().equals(imageSegment.getImageMode())) {
+            throw new IllegalStateException(String.format("%s: argument 'imageSegment' must have an ImageMode of '%s'.",
+                    getHandlerName(),
+                    getSupportedImageMode().getTextEquivalent()
+            ));
         }
     }
 
-
-    public void applyMask(ImageBlock block, ImageMask imageMask,
-            ImageRepresentationHandler imageRepresentationHandler) {
+    private void applyMask(ImageBlock block, ImageMask imageMask, ImageRepresentationHandler imageRepresentationHandler) {
         if (imageMask != null) {
             final int dataSize = block.getWidth() * block.getHeight();
-
             for (int pixel = 0; pixel < dataSize; ++pixel) {
                 if (imageMask.isPadPixel(block.getDataBuffer().getElem(pixel))) {
                     imageRepresentationHandler.renderPadPixel(block.getDataBuffer(), pixel);
@@ -110,4 +102,5 @@ public class BandSequentialImageModeHandler implements ImageModeHandler {
             }
         }
     }
+
 }


### PR DESCRIPTION
These share a mostly common implementation (because its really all just variation on how data is
arranged within a block).

Removes the RGB support from UncompressedBlockRenderer, since it is now all handled in the new API.

@dcruver 