### PR TITLE
[IMG-71] Implement masking support for each image mode.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
@@ -18,7 +18,6 @@ package org.codice.imaging.nitf.render.imagemode;
 import java.awt.Graphics2D;
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
@@ -65,7 +64,7 @@ public class BandSequentialImageModeHandler extends BaseImageModeHandler impleme
             final int index = bandIndex;
 
             matrix.forEachBlock(block -> {
-                readBlock(block, imageSegment.getData(), imageRepresentationHandler, index);
+                readBlock(block, imageSegment, imageRepresentationHandler, index);
                 applyMask(block, imageMask, imageRepresentationHandler);
             } );
         }
@@ -79,7 +78,7 @@ public class BandSequentialImageModeHandler extends BaseImageModeHandler impleme
         }
     }
 
-    private void readBlock(ImageBlock block, ImageInputStream imageInputStream,
+    private void readBlock(ImageBlock block, ImageSegment imageSegment,
             ImageRepresentationHandler imageRepresentationHandler, int bandIndex) {
 
         final DataBuffer data = block.getDataBuffer();
@@ -88,7 +87,7 @@ public class BandSequentialImageModeHandler extends BaseImageModeHandler impleme
             for (int row = 0; row < block.getHeight(); row++) {
                 for (int column = 0; column < block.getWidth(); column++) {
                     int i = row * block.getWidth() + column;
-                    imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                    imageRepresentationHandler.renderPixelBand(data, i, imageSegment, bandIndex);
                 }
             }
         } catch (IOException e) {

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
@@ -64,8 +64,10 @@ public class BandSequentialImageModeHandler extends BaseImageModeHandler impleme
             final int index = bandIndex;
 
             matrix.forEachBlock(block -> {
-                readBlock(block, imageSegment, imageRepresentationHandler, index);
-                applyMask(block, imageMask, imageRepresentationHandler);
+                if (!imageMask.isMaskedBlock(block.getBlockIndex(), index)) {
+                    readBlock(block, imageSegment, imageRepresentationHandler, index);
+                    applyMask(block, imageMask, imageRepresentationHandler);
+                }
             } );
         }
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
@@ -16,7 +16,6 @@ package org.codice.imaging.nitf.render.imagemode;
 
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
@@ -41,14 +40,13 @@ public class BlockInterleveImageModeHandler extends SharedImageModeHandler imple
     protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
 
         final DataBuffer data = block.getDataBuffer();
-        ImageInputStream imageInputStream = imageSegment.getData();
 
         try {
             for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
                 for (int row = 0; row < block.getHeight(); row++) {
                     for (int column = 0; column < block.getWidth(); column++) {
                         int i = row * block.getWidth() + column;
-                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                        imageRepresentationHandler.renderPixelBand(data, i, imageSegment, bandIndex);
                     }
                 }
             }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
@@ -14,7 +14,7 @@
  */
 package org.codice.imaging.nitf.render.imagemode;
 
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.util.function.Supplier;
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 public class ImageBlock {
     private int row;
     private int column;
+    private final int numColumns;
     private int width;
     private int height;
     private Supplier<BufferedImage> imageSupplier;
@@ -34,11 +35,13 @@ public class ImageBlock {
      *
      * @param row - the row position of this ImageBlock in the larger image.
      * @param column - the column position of this ImageBlock in the larger image.
+     * @param numColumns the number of columns in the ImageBlock.
      */
-    public ImageBlock(int row, int column, int width, int height,
+    public ImageBlock(int row, int column, int numColumns, int width, int height,
             Supplier<BufferedImage> imageSupplier) {
         this.row = row;
         this.column = column;
+        this.numColumns = numColumns;
         this.width = width;
         this.height = height;
         this.imageSupplier = imageSupplier;
@@ -72,4 +75,17 @@ public class ImageBlock {
         return height;
     }
 
+    /**
+     * Get the block index in standard rendering order.
+     *
+     * This is a zero-based index for the position of this block if the blocks were "linearised", such that the first
+     * block (column 0) of each row appears at the end of the last block of the previous row. As an example, if you have
+     * 3 rows of 4 columns, this will be a number between 0 and 11, where the first row has 0 to 3, the second row 4 to
+     * 7, and the third row 8 to 11.
+     *
+     * @return block index.
+     */
+    public int getBlockIndex() {
+        return (this.row * this.numColumns) + this.column;
+    }
 }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlockMatrix.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlockMatrix.java
@@ -42,7 +42,7 @@ class ImageBlockMatrix {
 
         for (int i = 0; i < this.getMatrixWidth(); i++) {
             for (int j = 0; j < this.getMatrixHeight(); j++) {
-                blocks[i][j] = new ImageBlock(i, j, blockWidth, blockHeight, imageSupplier);
+                blocks[i][j] = new ImageBlock(i, j, getMatrixWidth(), blockWidth, blockHeight, imageSupplier);
             }
         }
     }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
@@ -16,7 +16,6 @@ package org.codice.imaging.nitf.render.imagemode;
 
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
@@ -40,14 +39,13 @@ public class PixelInterleveImageModeHandler extends SharedImageModeHandler imple
     protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
 
         final DataBuffer data = block.getDataBuffer();
-        ImageInputStream imageInputStream = imageSegment.getData();
 
         try {
             for (int row = 0; row < block.getHeight(); row++) {
                 for (int column = 0; column < block.getWidth(); column++) {
                     for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
                         int i = row * block.getWidth() + column;
-                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                        imageRepresentationHandler.renderPixelBand(data, i, imageSegment, bandIndex);
                     }
                 }
             }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
@@ -16,7 +16,6 @@ package org.codice.imaging.nitf.render.imagemode;
 
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
@@ -41,14 +40,13 @@ public class RowInterleveImageModeHandler extends SharedImageModeHandler impleme
     protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
 
         final DataBuffer data = block.getDataBuffer();
-        ImageInputStream imageInputStream = imageSegment.getData();
 
         try {
             for (int row = 0; row < block.getHeight(); row++) {
                 for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
                     for (int column = 0; column < block.getWidth(); column++) {
                         int i = row * block.getWidth() + column;
-                        imageRepresentationHandler.renderPixelBand(data, i, imageInputStream, bandIndex);
+                        imageRepresentationHandler.renderPixelBand(data, i, imageSegment, bandIndex);
                     }
                 }
             }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
@@ -53,8 +53,10 @@ abstract class SharedImageModeHandler extends BaseImageModeHandler implements Im
                         imageSegment.getNumberOfPixelsPerBlockVertical()));
 
         matrix.forEachBlock(block -> {
-            readBlock(block, imageSegment, imageRepresentationHandler);
-            applyMask(block, imageMask, imageRepresentationHandler);
+            if (!imageMask.isMaskedBlock(block.getBlockIndex(), 0)) {
+                readBlock(block, imageSegment, imageRepresentationHandler);
+                applyMask(block, imageMask, imageRepresentationHandler);
+            }
         });
 
         matrix.forEachBlock((block) -> block.render(targetImage, true));

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandler.java
@@ -17,8 +17,7 @@ package org.codice.imaging.nitf.render.imagerep;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-
-import javax.imageio.stream.ImageInputStream;
+import org.codice.imaging.nitf.core.image.ImageSegment;
 
 /**
  * An ImageRepresentationHandler calculates the values for a given pixel based on the current pixel value
@@ -28,17 +27,19 @@ import javax.imageio.stream.ImageInputStream;
  */
 
 public interface ImageRepresentationHandler {
+
+    public static final int NOT_VISIBLE_MAPPED = -1;
+
     /**
      * Applies the bandValue to currentValue based on bandIndex.
      *
      * @param dataBuffer - the buffer that contains the pixel data.
      * @param pixelIndex - the index of the pixel being rendered.
-     * @param imageInputStream - the stream that contains the image data.
+     * @param imageSegment - the image segment that is being rendered.
      * @param bandIndex - the index of the band being applied, zero-based.
-     * @return - the new value for the current pixel.
      */
-    void renderPixelBand(DataBuffer dataBuffer, int pixelIndex, ImageInputStream imageInputStream,
-            int bandIndex) throws IOException;
+    void renderPixelBand(DataBuffer dataBuffer, int pixelIndex, ImageSegment imageSegment, int bandIndex)
+            throws IOException;
 
     /**
      *

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -15,17 +15,50 @@
 package org.codice.imaging.nitf.render.imagerep;
 
 import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.core.image.NitfImageBand;
 
 public class ImageRepresentationHandlerFactory {
     public static ImageRepresentationHandler forImageSegment(ImageSegment header) {
         switch (header.getImageRepresentation()) {
         case RGBTRUECOLOUR: {
             return new Rgb24ImageRepresentationHandler();
-        }
+            }
+            case MULTIBAND: {
+                return getHandlerForMultiband(header);
+            }
         //add other (more complex) cases here
         default:
             return null;
         }
     }
-}
 
+    private static ImageRepresentationHandler getHandlerForMultiband(ImageSegment header) {
+        if (irepbandsHasRgb(header)) {
+            return new Rgb24ImageRepresentationHandler();
+        }
+        return null;
+    }
+
+    private static boolean irepbandsHasRgb(ImageSegment header) {
+        boolean hasR = false;
+        boolean hasG = false;
+        boolean hasB = false;
+        for (int i = 0; i < header.getNumBands(); i++) {
+            NitfImageBand band = header.getImageBandZeroBase(i);
+            if (null != band.getImageRepresentation()) {
+                switch (band.getImageRepresentation()) {
+                    case "R":
+                        hasR = true;
+                        break;
+                    case "G":
+                        hasG = true;
+                        break;
+                    case "B":
+                        hasB = true;
+                        break;
+                }
+            }
+        }
+        return (hasR && hasG && hasB);
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/Rgb24ImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/Rgb24ImageRepresentationHandler.java
@@ -3,14 +3,15 @@ package org.codice.imaging.nitf.render.imagerep;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.io.IOException;
-
-import javax.imageio.stream.ImageInputStream;
+import org.codice.imaging.nitf.core.image.ImageSegment;
 
 public class Rgb24ImageRepresentationHandler implements ImageRepresentationHandler {
+
     @Override
-    public void renderPixelBand(DataBuffer data, int pixelIndex, ImageInputStream imageInputStream, int bandIndex)
+    public void renderPixelBand(DataBuffer data, int pixelIndex, ImageSegment imageSegment, int bandIndex)
             throws IOException {
-        data.setElem(pixelIndex, data.getElem(pixelIndex) | (imageInputStream.read() << (8 * (2 - bandIndex))));
+        int pixelShift = getPixelShiftForBand(imageSegment, bandIndex);
+        data.setElem(pixelIndex, data.getElem(pixelIndex) | (imageSegment.getData().read() << pixelShift));
     }
 
     @Override
@@ -18,11 +19,31 @@ public class Rgb24ImageRepresentationHandler implements ImageRepresentationHandl
         return new BufferedImage(blockWidth, blockHeight, BufferedImage.TYPE_INT_ARGB);
     }
 
+    @Override
     public void applyPixelMask(DataBuffer data, int pixelIndex) {
         data.setElem(pixelIndex, data.getElem(pixelIndex) | 0xFF000000);
     }
 
+    @Override
     public void renderPadPixel(DataBuffer data, int pixelIndex) {
         data.setElem(pixelIndex, 0x00000000);
+    }
+
+    private int getPixelShiftForBand(ImageSegment imageSegment, int bandIndex) {
+        int leftShift;
+        switch (imageSegment.getImageBandZeroBase(bandIndex).getImageRepresentation()) {
+            case "R":
+                leftShift = 16;
+                break;
+            case "G":
+                leftShift = 8;
+                break;
+            case "B":
+                leftShift = 0;
+                break;
+            default:
+                leftShift = NOT_VISIBLE_MAPPED;
+        }
+        return leftShift;
     }
 }

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
@@ -170,6 +170,11 @@ public class RenderJitcTest extends TestCase {
     }
 
     @Test
+    public void testNS3228B() throws IOException, ParseException {
+        testOneFile("ns3228b.nsf", "JitcNitf21Samples");
+    }
+
+    @Test
     public void testI_3228C() throws IOException, ParseException {
         testOneFile("i_3228c.ntf", "JitcNitf21Samples");
     }


### PR DESCRIPTION
This resolves the rendering problem with the v_3301f test case.

Unfortunately I don't have a BANDSEQUENTIAL test case to include, so that is "by analogy". I had hopes for a case in the JITC set (ns3061a.nsf), but the description was bogus - no image segment.