### PR TITLE
[IMG-84] Throw exception instead of logging for an unimplemented text form

### DIFF
--- a/cgm/src/main/java/org/codice/imaging/cgm/CgmInputReader.java
+++ b/cgm/src/main/java/org/codice/imaging/cgm/CgmInputReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Codice
+ * Copyright (c) 2014-2016, Codice
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Wrapper for CGM input data.
@@ -47,7 +45,6 @@ class CgmInputReader {
     private static final int NUM_BYTES_IN_SIGNED_VDC_INTEGER = 2;
     private static final int NUM_BYTES_IN_ENUM_VALUE = 2;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CgmInputReader.class);
     private final DataInput dataStream;
 
     CgmInputReader(final byte[] cgmData) {
@@ -80,7 +77,7 @@ class CgmInputReader {
     String getStringFixed() throws IOException {
         int count = dataStream.readUnsignedByte();
         if (count > LONG_COUNT_FLAG_VALUE) {
-            LOGGER.info("Need to handle long count");
+            throw new UnsupportedOperationException("[IMG-98] CGM does not yet support long form strings.");
         }
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < count; ++i) {

--- a/cgm/src/test/java/org/codice/imaging/cgm/CgmInputReaderTest.java
+++ b/cgm/src/test/java/org/codice/imaging/cgm/CgmInputReaderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016, Codice
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.codice.imaging.cgm;
+
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for CgmInputReader class
+ */
+public class CgmInputReaderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    public CgmInputReaderTest() {
+    }
+
+    // This test will not be applicable after IMG-98 is resolved.
+    @Test
+    public void checkLongFormStringReadException() throws IOException {
+        byte[] testData = new byte[]{(byte) 0xFF, (byte) 0x02, (byte) 0x00};
+        CgmInputReader reader = new CgmInputReader(testData);
+        exception.expect(UnsupportedOperationException.class);
+        exception.expectMessage("[IMG-98] CGM does not yet support long form strings.");
+        reader.getStringFixed();
+    }
+}


### PR DESCRIPTION
If we don't handle the long text form, it'll break parsing anyway, so an exception is better.

I added a test case, and created a ticket at https://codice.atlassian.net/browse/IMG-98 to explain what the issue really is.