### PR TITLE
img-99 add 'getSupportedImageMode()' to all ImageModeHandlers

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
@@ -25,7 +25,7 @@ import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.ImageMask;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
 
-public class BandSequentialImageModeHandler implements ImageModeHandler {
+public class BandSequentialImageModeHandler extends BaseImageModeHandler implements ImageModeHandler {
     private static final String NULL_ARG_ERROR_MESSAGE =
             "BandSequentialImageModeHandler(): argument '%s' may not be null.";
 
@@ -40,6 +40,7 @@ public class BandSequentialImageModeHandler implements ImageModeHandler {
         checkNull(imageSegment, "imageSegment");
         checkNull(targetImage, "targetImage");
         checkNull(imageRepresentationHandler, "imageRepresentationHandler");
+        checkImageMode(imageSegment);
 
         ImageMask iMask = null;
 
@@ -109,5 +110,15 @@ public class BandSequentialImageModeHandler implements ImageModeHandler {
                 }
             }
         }
+    }
+
+    @Override
+    public ImageMode getSupportedImageMode() {
+        return ImageMode.BANDSEQUENTIAL;
+    }
+
+    @Override
+    String getHandlerName() {
+        return "BandSequentialImageModeHandler";
     }
 }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BaseImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BaseImageModeHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagemode;
+
+import org.codice.imaging.nitf.core.image.ImageMode;
+import org.codice.imaging.nitf.core.image.ImageSegment;
+
+abstract class BaseImageModeHandler implements ImageModeHandler {
+
+    abstract ImageMode getSupportedImageMode();
+
+    abstract String getHandlerName();
+
+    protected void checkImageMode(ImageSegment imageSegment) throws IllegalStateException {
+        if (!getSupportedImageMode().equals(imageSegment.getImageMode())) {
+            throw new IllegalStateException(String.format("%s: argument 'imageSegment' must have an ImageMode of '%s'.",
+                    getHandlerName(),
+                    getSupportedImageMode().getTextEquivalent()
+            ));
+        }
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
@@ -17,7 +17,6 @@ package org.codice.imaging.nitf.render.imagemode;
 import java.awt.Graphics2D;
 import java.io.IOException;
 import org.codice.imaging.nitf.core.image.ImageCompression;
-import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.ImageMask;
 import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
@@ -25,7 +24,7 @@ import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
 /**
  * A shared implementation of the various ImageModeHandler cases.
  */
-abstract class SharedImageModeHandler implements ImageModeHandler {
+abstract class SharedImageModeHandler extends BaseImageModeHandler implements ImageModeHandler {
     protected static final String NULL_ARG_ERROR_MESSAGE = "%s: argument '%s' may not be null.";
 
     /**
@@ -61,10 +60,6 @@ abstract class SharedImageModeHandler implements ImageModeHandler {
         matrix.forEachBlock((block) -> block.render(targetImage, true));
     }
 
-    protected abstract String getHandlerName();
-
-    protected abstract ImageMode getSupportedImageMode();
-
     protected abstract void readBlock(ImageBlock block, ImageSegment imageSegment,
             ImageRepresentationHandler imageRepresentationHandler);
 
@@ -78,15 +73,6 @@ abstract class SharedImageModeHandler implements ImageModeHandler {
     private void checkNull(Object value, String valueName) {
         if (value == null) {
             throw new IllegalArgumentException(String.format(NULL_ARG_ERROR_MESSAGE, getHandlerName(), valueName));
-        }
-    }
-
-    private void checkImageMode(ImageSegment imageSegment) throws IllegalStateException {
-        if (!getSupportedImageMode().equals(imageSegment.getImageMode())) {
-            throw new IllegalStateException(String.format("%s: argument 'imageSegment' must have an ImageMode of '%s'.",
-                    getHandlerName(),
-                    getSupportedImageMode().getTextEquivalent()
-            ));
         }
     }
 


### PR DESCRIPTION
added 'BaseImageModeHandler' as an abstract class and updated all existing ImageModeHandlers to extend from that.  That class requires the 'getSupportedImageMode()' and 'getHandlerName()' methods and provides the 'checkImageMode' method to subclasses.

@bradh 