### PR TITLE
[IMG-71] Implement masking support for each image mode.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
@@ -71,9 +71,11 @@ class BandSequentialImageModeHandler extends BaseImageModeHandler implements Ima
             final int index = bandIndex;
 
             matrix.forEachBlock(block -> {
-                readBlock(block, imageSegment.getData(), index);
-                applyMask(block, imageMask, imageRepresentationHandler);
-            } );
+                if (!imageMask.isMaskedBlock(block.getBlockIndex(), index)) {
+                    readBlock(block, imageSegment.getData(), index);
+                    applyMask(block, imageMask);
+                }
+            });
         }
 
         matrix.forEachBlock((block) -> block.render(targetImage, true));
@@ -102,8 +104,7 @@ class BandSequentialImageModeHandler extends BaseImageModeHandler implements Ima
     }
 
 
-    public void applyMask(ImageBlock block, ImageMask imageMask,
-            ImageRepresentationHandler imageRepresentationHandler) {
+    public void applyMask(ImageBlock block, ImageMask imageMask) {
         if (imageMask != null) {
             final int dataSize = block.getWidth() * block.getHeight();
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BlockInterleveImageModeHandler.java
@@ -41,7 +41,7 @@ class BlockInterleveImageModeHandler extends SharedImageModeHandler implements I
     }
 
     @Override
-    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment) {
 
         final DataBuffer data = block.getDataBuffer();
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
@@ -14,7 +14,7 @@
  */
 package org.codice.imaging.nitf.render.imagemode;
 
-import java.awt.*;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.util.function.Supplier;
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 public class ImageBlock {
     private int row;
     private int column;
+    private final int numColumns;
     private int width;
     private int height;
     private Supplier<BufferedImage> imageSupplier;
@@ -34,11 +35,13 @@ public class ImageBlock {
      *
      * @param row - the row position of this ImageBlock in the larger image.
      * @param column - the column position of this ImageBlock in the larger image.
+     * @param numColumns the number of columns in the ImageBlock.
      */
-    public ImageBlock(int row, int column, int width, int height,
+    public ImageBlock(int row, int column, int numColumns, int width, int height,
             Supplier<BufferedImage> imageSupplier) {
         this.row = row;
         this.column = column;
+        this.numColumns = numColumns;
         this.width = width;
         this.height = height;
         this.imageSupplier = imageSupplier;
@@ -72,4 +75,17 @@ public class ImageBlock {
         return height;
     }
 
+    /**
+     * Get the block index in standard rendering order.
+     *
+     * This is a zero-based index for the position of this block if the blocks were "linearised", such that the first
+     * block (column 0) of each row appears at the end of the last block of the previous row. As an example, if you have
+     * 3 rows of 4 columns, this will be a number between 0 and 11, where the first row has 0 to 3, the second row 4 to
+     * 7, and the third row 8 to 11.
+     *
+     * @return block index.
+     */
+    public int getBlockIndex() {
+        return (this.row * this.numColumns) + this.column;
+    }
 }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlockMatrix.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlockMatrix.java
@@ -42,7 +42,7 @@ class ImageBlockMatrix {
 
         for (int i = 0; i < this.getMatrixWidth(); i++) {
             for (int j = 0; j < this.getMatrixHeight(); j++) {
-                blocks[i][j] = new ImageBlock(i, j, blockWidth, blockHeight, imageSupplier);
+                blocks[i][j] = new ImageBlock(i, j, getMatrixWidth(), blockWidth, blockHeight, imageSupplier);
             }
         }
     }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/PixelInterleveImageModeHandler.java
@@ -40,7 +40,7 @@ class PixelInterleveImageModeHandler extends SharedImageModeHandler implements I
     }
 
     @Override
-    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment) {
 
         final DataBuffer data = block.getDataBuffer();
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/RowInterleveImageModeHandler.java
@@ -41,7 +41,7 @@ class RowInterleveImageModeHandler extends SharedImageModeHandler implements Ima
     }
 
     @Override
-    protected void readBlock(ImageBlock block, ImageSegment imageSegment, ImageRepresentationHandler imageRepresentationHandler) {
+    protected void readBlock(ImageBlock block, ImageSegment imageSegment) {
 
         final DataBuffer data = block.getDataBuffer();
 

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/SharedImageModeHandler.java
@@ -59,15 +59,16 @@ abstract class SharedImageModeHandler extends BaseImageModeHandler implements Im
                         imageSegment.getNumberOfPixelsPerBlockVertical()));
 
         matrix.forEachBlock(block -> {
-            readBlock(block, imageSegment, imageRepresentationHandler);
-            applyMask(block, imageMask, imageRepresentationHandler);
+            if (!imageMask.isMaskedBlock(block.getBlockIndex(), 0)) {
+                readBlock(block, imageSegment);
+                applyMask(block, imageMask);
+            }
         });
 
         matrix.forEachBlock((block) -> block.render(targetImage, true));
     }
 
-    protected abstract void readBlock(ImageBlock block, ImageSegment imageSegment,
-            ImageRepresentationHandler imageRepresentationHandler);
+    protected abstract void readBlock(ImageBlock block, ImageSegment imageSegment);
 
     private void nullCheckArguments(ImageSegment imageSegment, Graphics2D targetImage,
             ImageRepresentationHandler imageRepresentationHandler) {
@@ -82,7 +83,7 @@ abstract class SharedImageModeHandler extends BaseImageModeHandler implements Im
         }
     }
 
-    private void applyMask(ImageBlock block, ImageMask imageMask, ImageRepresentationHandler imageRepresentationHandler) {
+    private void applyMask(ImageBlock block, ImageMask imageMask) {
         if (imageMask != null) {
             final int dataSize = block.getWidth() * block.getHeight();
             for (int pixel = 0; pixel < dataSize; ++pixel) {


### PR DESCRIPTION
This resolves the rendering problem with the v_3301f test case. Unfortunately I don't have a
BANDSEQUENTIAL test case to include, so that is "by analogy".

There is also a simplification of the ImageRepresentationHandler interface.