### PR TITLE
[IMG-106] Fix maven build on windows.

### DIFF
--- a/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
+++ b/cgm/src/test/java/org/codice/imaging/cgm/CgmParserTest.java
@@ -135,7 +135,7 @@ public class CgmParserTest {
     }
 
     private void testOneImage(String parentDirectory, String testfile) throws IOException {
-        String inputFileName = File.separator + parentDirectory + File.separator + testfile;
+        String inputFileName = "/" + parentDirectory + "/" + testfile;
         LOGGER.info("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
         try {

--- a/core/src/test/java/org/codice/imaging/nitf/core/AbstractWriterTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/AbstractWriterTest.java
@@ -50,10 +50,12 @@ class AbstractWriterTest {
         assertTrue(new File(outputFile).delete());
 
         // Do the same again, but with stream writing
-        OutputStream outputStream = new FileOutputStream(outputFile);
-        writer = new NitfOutputStreamWriter(parseStrategy, outputStream);
-        writer.write();
-        assertTrue(FileUtils.contentEquals(new File(getClass().getResource(sourceFileName).toURI()), new File(outputFile)));
+        try (
+            OutputStream outputStream = new FileOutputStream(outputFile)) {
+            writer = new NitfOutputStreamWriter(parseStrategy, outputStream);
+            writer.write();
+            assertTrue(FileUtils.contentEquals(new File(getClass().getResource(sourceFileName).toURI()), new File(outputFile)));
+        }
         assertTrue(new File(outputFile).delete());
     }
 }

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderJitcTest.java
@@ -286,7 +286,7 @@ public class RenderJitcTest extends TestCase {
 
     private void testOneFile(final String testfile, final String parentDirectory)
             throws IOException, ParseException {
-        String inputFileName = File.separator + parentDirectory + File.separator + testfile;
+        String inputFileName = "/" + parentDirectory + "/" + testfile;
         LOGGER.info("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
 


### PR DESCRIPTION
There were two issues - use of File.seperator in resource files, and a missing stream close.