### PR TITLE
img-86 Expand fluent API to allow access to non-image segment types

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ This will compile imaging-nitf and run all of the tests.
     NitfFileParser.parse(reader, parseStrategy);
     NitfFileHeader nitfFileHeader = parseStrategy.getNitfHeader();
 ```
+
+## Using the Flow API
+
+```java
+    File resourceFile = new File("sample.ntf");
+    new NitfParserInputFlow()
+          .file(resourceFile)
+          .allData()
+          .fileHeader((header) -> handleFileHeader(header))
+          .forEachImageSegment((imageSegment) -> handleImageSegment(imageSegment))
+          .forEachDataSegment((dataSegment) -> handleDataSegment(dataSegment))
+          .forEachSymbolSegment((symbolSegment) -> handleSymbolSegment(symbolSegment))
+          .forEachGraphicSegment((graphicSegment) -> handleGraphicSegment(graphicSegment))
+          .forEachTextSegment((textSegment) -> handleTextSegment(textSegment))
+          .forEachLabelSegment((labelSegment) -> handleLabelSegment(labelSegment));
+```

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
@@ -16,10 +16,17 @@ package org.codice.imaging.nitf.render.flow;
 
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import org.codice.imaging.nitf.core.NitfDataSource;
 import org.codice.imaging.nitf.core.NitfFileHeader;
+import org.codice.imaging.nitf.core.common.CommonNitfSegment;
 import org.codice.imaging.nitf.core.dataextension.DataExtensionSegment;
+import org.codice.imaging.nitf.core.graphic.GraphicSegment;
 import org.codice.imaging.nitf.core.image.ImageSegment;
+import org.codice.imaging.nitf.core.label.LabelSegment;
+import org.codice.imaging.nitf.core.symbol.SymbolSegment;
+import org.codice.imaging.nitf.core.text.TextSegment;
 
 /**
  * The NitfSegmentsFlow provides methods for processing the contents of the NITF file.
@@ -38,36 +45,6 @@ public class NitfSegmentsFlow {
     }
 
     /**
-     * Iterates over the images in the NITF file and passes them to the supplied consumer.
-     *
-     * @param consumer The consumer to pass the image segment to.
-     * @return this NitfSegmentsFlow.
-     */
-    public NitfSegmentsFlow forEachImage(Consumer<ImageSegment> consumer) {
-        for (ImageSegment imageSegment : mDataSource.getImageSegments()) {
-            consumer.accept(imageSegment);
-        }
-
-        return this;
-    }
-
-    /**
-     * Iterates over the data extension segments in the NITF file and passes them to the supplied consumer.
-     *
-     * @param consumer The consumer to pass the data extension segment to.
-     * @return this NitfSegmentsFlow.
-     */
-    public NitfSegmentsFlow forEachDataSegment(Consumer<DataExtensionSegment> consumer) {
-        List<DataExtensionSegment> headers = mDataSource.getDataExtensionSegments();
-
-        for (DataExtensionSegment header : headers) {
-            consumer.accept(header);
-        }
-
-        return this;
-    }
-
-    /**
      * Passes the NITF file header to the supplied consumer.
      *
      * @param consumer the consumer to pass the NITF file header to.
@@ -76,6 +53,80 @@ public class NitfSegmentsFlow {
     public NitfSegmentsFlow fileHeader(Consumer<NitfFileHeader> consumer) {
         NitfFileHeader nitfFileHeader = mDataSource.getNitfHeader();
         consumer.accept(nitfFileHeader);
+        return this;
+    }
+
+    /**
+     * Iterates over the images in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the image segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachImageSegment(Consumer<ImageSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getImageSegments());
+    }
+
+    /**
+     * Iterates over the data extension segments in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the data extension segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachDataExtensionSegment(Consumer<DataExtensionSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getDataExtensionSegments());
+    }
+
+    /**
+     * Iterates over the text segments in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the text segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachTextSegment(Consumer<TextSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getTextSegments());
+    }
+
+    /**
+     * Iterates over the graphic segments in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the graphic segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachGraphicSegment(Consumer<GraphicSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getGraphicSegments());
+    }
+
+    /**
+     * Iterates over the label segments in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the label segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachLabelSegment(Consumer<LabelSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getLabelSegments());
+    }
+
+    /**
+     * Iterates over the symbol segments in the NITF file and passes them to the supplied consumer.
+     *
+     * @param consumer The consumer to pass the symbol segment to.
+     * @return this NitfSegmentsFlow.
+     */
+    public NitfSegmentsFlow forEachSymbolSegment(Consumer<SymbolSegment> consumer) {
+        return forEachSegment(consumer, () -> mDataSource.getSymbolSegments());
+    }
+
+    private <T extends CommonNitfSegment> NitfSegmentsFlow forEachSegment(Consumer<T> consumer, Supplier<List<T>> supplier) {
+        if (consumer != null && supplier != null) {
+            List<T> segments = supplier.get();
+
+            if (segments != null) {
+                for (T segment : segments) {
+                    consumer.accept(segment);
+                }
+            }
+        }
+
         return this;
     }
 }

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/package-info.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/package-info.java
@@ -23,11 +23,17 @@
  *
  * <pre>
  * {@code
+ *   File resourceFile = new File("sample.ntf");
  *   new NitfParserInputFlow()
- *       .inputStream(getImageInputStream())
- *       .allData()
- *       .fileHeader(header -> LOGGER.debug(header.getIdentifier())
- *       .forEachImage((header, imageInputStream) -> renderImage(header, imageInputStream);
+ *         .file(resourceFile)
+ *         .allData()
+ *         .fileHeader((header) -> handleFileHeader(header))
+ *         .forEachImageSegment((imageSegment) -> handleImageSegment(imageSegment))
+ *         .forEachDataSegment((dataSegment) -> handleDataSegment(dataSegment))
+ *         .forEachSymbolSegment((symbolSegment) -> handleSymbolSegment(symbolSegment))
+ *         .forEachGraphicSegment((graphicSegment) -> handleGraphicSegment(graphicSegment))
+ *         .forEachTextSegment((textSegment) -> handleTextSegment(textSegment))
+ *         .forEachLabelSegment((labelSegment) -> handleLabelSegment(labelSegment));
  * }
  * </pre>
  */

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderTestSupport.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderTestSupport.java
@@ -18,12 +18,15 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+
 import javax.imageio.ImageIO;
-import junit.framework.TestCase;
+
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.flow.NitfParserInputFlow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
 
 /**
  * Shared code for rendering tests
@@ -52,7 +55,7 @@ public class RenderTestSupport extends TestCase {
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
         final ThreadLocal<Integer> i = new ThreadLocal<>();
         i.set(0);
-        new NitfParserInputFlow().inputStream(getClass().getResourceAsStream(inputFileName)).imageData().forEachImage((ImageSegment segment) -> {
+        new NitfParserInputFlow().inputStream(getClass().getResourceAsStream(inputFileName)).imageData().forEachImageSegment((ImageSegment segment) -> {
             NitfRenderer renderer = new NitfRenderer();
             try {
                 BufferedImage img = renderer.render(segment);


### PR DESCRIPTION
This change adds methods to the fluent API to handle all of the image segment types.
Also updates the README.md file and package-info.java.