### PR TITLE
img-119 ArrayIndexOutOfBoundsException from ImageMask.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/ImageMask.java
@@ -118,6 +118,11 @@ public final class ImageMask {
         if (bmrnbndm == null) {
             return false;
         }
+
+        if (blockNumber >= bmrnbndm.length || bandNumber >= bmrnbndm[blockNumber].length) {
+            return false;
+        }
+
         return (BLOCK_NOT_RECORDED == bmrnbndm[blockNumber][bandNumber]);
     }
 


### PR DESCRIPTION
Added bounds checks to ImageMask.isMaskedBlock(int, int).