### PR TITLE
[IMG-117] Correct and simplify the segment inheritance.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfFileHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfFileHeader.java
@@ -14,19 +14,19 @@
  */
 package org.codice.imaging.nitf.core;
 
+import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandlerImpl;
 import java.util.ArrayList;
 import java.util.List;
 import static org.codice.imaging.nitf.core.NitfConstants.DEFAULT_ORIGINATING_STATION;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
-import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityMetadataFactory;
 
 /**
     NITF file data.
 */
-public class NitfFileHeader extends AbstractNitfSegment {
+public class NitfFileHeader extends TaggedRecordExtensionHandlerImpl {
     private FileType fileType = FileType.UNKNOWN;
     private int nitfComplexityLevel = 0;
     private String nitfStandardType = null;
@@ -455,19 +455,25 @@ public class NitfFileHeader extends AbstractNitfSegment {
     }
 
     /**
-     * {@inheritDoc}
+     * Get the file-level security metadata for the file.
+     *
+     * See FileSecurityMetadata for the various elements, which differ slightly between NITF 2.0 and NITF 2.1/NSIF 1.0.
+     *
+     * @return file security metadata
      */
-    @Override
-    public final String getIdentifier() {
-        return null;
+    public final FileSecurityMetadata getSecurityMetadata() {
+        return this.fileSecurityMetadata;
     }
 
     /**
-     * {@inheritDoc}
+     * Set the file-level security metadata for the file.
+     *
+     * See FileSecurityMetadata for the various elements, which differ slightly between NITF 2.0 and NITF 2.1/NSIF 1.0.
+     *
+     * @param fsmeta the security metadata to set.
      */
-    @Override
-    public final SecurityMetadata getSecurityMetadata() {
-        return this.fileSecurityMetadata;
+    public final void setSecurityMetadata(final FileSecurityMetadata fsmeta) {
+        this.fileSecurityMetadata = fsmeta;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonBasicSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonBasicSegment.java
@@ -19,7 +19,7 @@ package org.codice.imaging.nitf.core.common;
  <p>
  This excludes the Data Extension Segment subheader.
  */
-public interface CommonNitfSubSegment extends CommonNitfSegment {
+public interface CommonBasicSegment extends CommonSegment {
 
     /**
      Return the extended subheader overflow index (IXSOFL/SXSOFL/LXSOFL/TXSOFL).
@@ -32,6 +32,15 @@ public interface CommonNitfSubSegment extends CommonNitfSegment {
     int getExtendedHeaderDataOverflow();
 
     /**
+     * Set the extended subheader overflow index (IXSOFL/SXSOFL/LXSOFL/TXSOFL).
+     * <p>
+     * This is the (1-base) index of the TRE into which extended header data overflows.
+     *
+     * @param overflow the extended header data overflow index
+     */
+    void setExtendedHeaderDataOverflow(final int overflow);
+
+    /**
      Return the attachment level for the segment.
      <p>
      The valid values for this are zero (not attached) or the display level
@@ -41,4 +50,15 @@ public interface CommonNitfSubSegment extends CommonNitfSegment {
      @return the attachment level
      */
     int getAttachmentLevel();
+
+    /**
+     * Set the attachment level for the segment.
+     * <p>
+     * The valid values for this are zero (not attached) or the display level for an image, graphic, symbol or label (as
+     * appropriate to the NITF file type) in the file.
+     *
+     * @param attachmentLevel the attachment level
+     */
+    void setAttachmentLevel(final int attachmentLevel);
+
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonBasicSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonBasicSegmentImpl.java
@@ -12,29 +12,22 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
-
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+package org.codice.imaging.nitf.core.common;
 
 /**
  * Common data elements for NITF data segments.
  *
  * This excludes the Data Extension Segment.
  */
-public abstract class AbstractSubSegment extends AbstractCommonNitfSegment
-        implements CommonNitfSubSegment {
+public abstract class CommonBasicSegmentImpl extends CommonSegmentImpl implements CommonBasicSegment {
 
     private int extendedHeaderDataOverflow = 0;
     private int segmentAttachmentLevel = 0;
 
     /**
-        Set the extended subheader overflow index (IXSOFL/SXSOFL/LXSOFL/TXSOFL).
-        <p>
-        This is the (1-base) index of the TRE into which extended header data
-        overflows.
-
-        @param overflow the extended header data overflow index
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setExtendedHeaderDataOverflow(final int overflow) {
         extendedHeaderDataOverflow = overflow;
     }
@@ -48,14 +41,9 @@ public abstract class AbstractSubSegment extends AbstractCommonNitfSegment
     }
 
     /**
-        Set the attachment level for the segment.
-        <p>
-        The valid values for this are zero (not attached) or the display level
-        for an image, graphic, symbol or label (as appropriate to the NITF file type)
-        in the file.
-
-        @param attachmentLevel the attachment level
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setAttachmentLevel(final int attachmentLevel) {
         segmentAttachmentLevel = attachmentLevel;
     }
@@ -67,5 +55,4 @@ public abstract class AbstractSubSegment extends AbstractCommonNitfSegment
     public final int getAttachmentLevel() {
         return segmentAttachmentLevel;
     }
-
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegment.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.common;
+
+import org.codice.imaging.nitf.core.security.SecurityMetadata;
+
+/**
+ * Common data elements for NITF segments.
+ *
+ * This includes image segments, symbol segments, graphic segments, label segments, text segments and data extension
+ * segments.
+ *
+ */
+public interface CommonSegment extends TaggedRecordExtensionHandler {
+
+    /**
+     * Return the identifier (IID1/SID/LID/TEXTID/DESID) for the segment.
+     * <p>
+     * This field shall contain a valid alphanumeric identification code associated with the segment. The valid codes
+     * are determined by the application.
+     *
+     * @return the identifier
+     */
+    String getIdentifier();
+
+    /**
+     * Set the identifier (IID1/SID/LID/TEXTID/DESID) for the segment.
+     * <p>
+     * This field shall contain a valid alphanumeric identification code associated with the segment. The valid codes
+     * are determined by the application.
+     *
+     * @param identifier the identifier for the segment
+     */
+    void setIdentifier(final String identifier);
+
+    /**
+     * Return the segment-level security metadata for the segment.
+     *
+     * @return security metadata
+     */
+    SecurityMetadata getSecurityMetadata();
+
+    /**
+     * Set the segment-level security metadata elements for the segment.
+     *
+     * See SecurityMetadata for the various elements, which differ slightly between NITF 2.0 and NITF 2.1/NSIF 1.0.
+     *
+     * @param metaData the security metadata values to set.
+     */
+    void setSecurityMetadata(final SecurityMetadata metaData);
+
+
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegmentImpl.java
@@ -12,26 +12,23 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.common;
 
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 
 /**
-    Common data elements for NITF segment subheaders.
-*/
-public abstract class AbstractCommonNitfSegment extends AbstractNitfSegment
-        implements org.codice.imaging.nitf.core.common.CommonNitfSegment {
+ * Implementation of common data elements for NITF segments.
+ *
+ * This includes image segments, symbol segments, graphic segments, label segments, text segments and data extension
+ * segments.
+ */
+public class CommonSegmentImpl extends TaggedRecordExtensionHandlerImpl implements CommonSegment {
 
-    private String segmentIdentifier = null;
+    private String segmentIdentifier;
     private SecurityMetadata securityMetadata = null;
 
     /**
-     Set the identifier (IID1/SID/LID/TEXTID) for the segment.
-     <p>
-     This field shall contain a valid alphanumeric identification code associated with the
-     segment. The valid codes are determined by the application.
-
-     @param identifier the identifier for the segment
+     * {@inheritDoc}
      */
     public final void setIdentifier(final String identifier) {
         segmentIdentifier = identifier;
@@ -46,12 +43,9 @@ public abstract class AbstractCommonNitfSegment extends AbstractNitfSegment
     }
 
     /**
-        Set the security metadata elements for the segment.
-
-        See SecurityMetadata for the various elements, which differ slightly between NITF 2.0 and NITF 2.1/NSIF 1.0.
-
-        @param metaData the security metadata values to set.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setSecurityMetadata(final SecurityMetadata metaData) {
         this.securityMetadata = metaData;
     }
@@ -63,5 +57,6 @@ public abstract class AbstractCommonNitfSegment extends AbstractNitfSegment
     public final SecurityMetadata getSecurityMetadata() {
         return securityMetadata;
     }
+
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/TaggedRecordExtensionHandler.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/TaggedRecordExtensionHandler.java
@@ -15,37 +15,12 @@
 package org.codice.imaging.nitf.core.common;
 
 import java.util.Map;
-import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 
 /**
- Common data elements for NITF segment subheaders.
+ * Tagged Record Extension (TRE) handler functionality.
  */
-public interface CommonNitfSegment {
-
-    /**
-     Return the identifier (IID1/SID/LID/TEXTID) for the segment.
-     <p>
-     This field shall contain a valid alphanumeric identification code associated with the
-     segment. The valid codes are determined by the application.
-
-     @return the identifier
-     */
-    String getIdentifier();
-
-    /**
-     Return the security metadata for the segment.
-
-     @return security metadata
-     */
-    SecurityMetadata getSecurityMetadata();
-
-    /**
-     Return the TREs for this segment, in raw form.
-
-     @return TRE collection
-     */
-    TreCollection getTREsRawStructure();
+public interface TaggedRecordExtensionHandler {
 
     /**
      * Return the TREs for this segment in a flattened Map structure.
@@ -53,4 +28,11 @@ public interface CommonNitfSegment {
      * @return a java.util.Map containing the TREs.
      */
     Map<String, String> getTREsFlat();
+
+    /**
+    Return the TREs for this segment, in raw form.
+    @return TRE collection
+     */
+    TreCollection getTREsRawStructure();
+
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/TaggedRecordExtensionHandlerImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/TaggedRecordExtensionHandlerImpl.java
@@ -12,12 +12,11 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.common;
 
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreEntry;
@@ -26,7 +25,7 @@ import org.codice.imaging.nitf.core.tre.TreGroup;
 /**
  * Common data elements for NITF segments and file header.
  */
-public abstract class AbstractNitfSegment implements CommonNitfSegment {
+public abstract class TaggedRecordExtensionHandlerImpl implements TaggedRecordExtensionHandler {
 
     private final TreCollection treCollection = new TreCollection();
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
@@ -14,14 +14,14 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
+import org.codice.imaging.nitf.core.common.CommonSegment;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 
 /**
  Common data extension segment parsing functionality.
  */
-public interface DataExtensionSegment extends CommonNitfSegment {
+public interface DataExtensionSegment extends CommonSegment {
 
     /**
      Return the DES version (DESVER).

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
@@ -14,7 +14,7 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
-import org.codice.imaging.nitf.core.AbstractCommonNitfSegment;
+import org.codice.imaging.nitf.core.common.CommonSegmentImpl;
 import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.CONTROLLED_EXTENSIONS;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.REGISTERED_EXTENSIONS;
@@ -24,8 +24,7 @@ import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.
 /**
     Data Extension Segment (DES) subheader and associated data.
 */
-class DataExtensionSegmentImpl extends AbstractCommonNitfSegment
-        implements DataExtensionSegment {
+class DataExtensionSegmentImpl extends CommonSegmentImpl implements DataExtensionSegment {
 
     private int desVersion = -1;
     private String overflowedHeaderType = null;

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegment.java
@@ -15,12 +15,12 @@
 package org.codice.imaging.nitf.core.graphic;
 
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 
 /**
  * Common graphic segment parsing functionality.
  */
-public interface GraphicSegment extends CommonNitfSubSegment {
+public interface GraphicSegment extends CommonBasicSegment {
     /**
      Return the graphic name (SNAME).
      <p>

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentImpl.java
@@ -15,12 +15,12 @@
 package org.codice.imaging.nitf.core.graphic;
 
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.AbstractSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
 
 /**
     Graphic segment information (NITF 2.1 / NSIF 1.0 only).
 */
-class GraphicSegmentImpl extends AbstractSubSegment
+class GraphicSegmentImpl extends CommonBasicSegmentImpl
         implements GraphicSegment {
 
     private String graphicName = null;

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
@@ -16,13 +16,13 @@ package org.codice.imaging.nitf.core.image;
 
 import java.util.List;
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 
 /**
  Image segment information.
  */
-public interface ImageSegment extends CommonNitfSubSegment {
+public interface ImageSegment extends CommonBasicSegment {
 
     /**
      Return the date / time (IDATIM) for the image.

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentImpl.java
@@ -17,13 +17,13 @@ package org.codice.imaging.nitf.core.image;
 import java.util.ArrayList;
 import java.util.List;
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.AbstractSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 
 /**
     Image segment information.
 */
-class ImageSegmentImpl extends AbstractSubSegment implements ImageSegment {
+class ImageSegmentImpl extends CommonBasicSegmentImpl implements ImageSegment {
 
     private NitfDateTime imageDateTime = null;
     private TargetId imageTargetId = null;

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegment.java
@@ -15,13 +15,13 @@
 package org.codice.imaging.nitf.core.label;
 
 import org.codice.imaging.nitf.core.RGBColour;
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 
 
 /**
  Label segment subheader information (NITF 2.0 only).
  */
-public interface LabelSegment extends CommonNitfSubSegment {
+public interface LabelSegment extends CommonBasicSegment {
 
     /**
      Return the row part of the label location (LLOC).

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
@@ -14,13 +14,13 @@
  */
 package org.codice.imaging.nitf.core.label;
 
-import org.codice.imaging.nitf.core.AbstractSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
 import org.codice.imaging.nitf.core.RGBColour;
 
 /**
     Label segment information (NITF 2.0 only).
 */
-class LabelSegmentImpl extends AbstractSubSegment implements LabelSegment {
+class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
 
     private int labelLocationRow = 0;
     private int labelLocationColumn = 0;

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegment.java
@@ -15,12 +15,12 @@
 package org.codice.imaging.nitf.core.symbol;
 
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 
 /**
  Symbol segment information (NITF 2.0 only).
  */
-public interface SymbolSegment extends CommonNitfSubSegment {
+public interface SymbolSegment extends CommonBasicSegment {
 
     /**
      Return the symbol name (SNAME).

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentImpl.java
@@ -15,12 +15,12 @@
 package org.codice.imaging.nitf.core.symbol;
 
 import javax.imageio.stream.ImageInputStream;
-import org.codice.imaging.nitf.core.AbstractSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
 
 /**
     Symbol segment information (NITF 2.0 only).
 */
-class SymbolSegmentImpl extends AbstractSubSegment implements SymbolSegment {
+class SymbolSegmentImpl extends CommonBasicSegmentImpl implements SymbolSegment {
 
     private String symbolName = null;
     private SymbolType symbolType = null;

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegment.java
@@ -14,13 +14,13 @@
  */
 package org.codice.imaging.nitf.core.text;
 
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 
 /**
  * Represents a NITF Text Segment.
  */
-public interface TextSegment extends CommonNitfSubSegment {
+public interface TextSegment extends CommonBasicSegment {
 
     /**
      Return text date and time.
@@ -32,6 +32,15 @@ public interface TextSegment extends CommonNitfSubSegment {
     NitfDateTime getTextDateTime();
 
     /**
+     * Set text date and time.
+     *
+     * This field shall contain the time (UTC) (Zulu) of origination of the text.
+     *
+     * @param dateTime the date and time of the text.
+     */
+    void setTextDateTime(final NitfDateTime dateTime);
+
+    /**
      Return text title.
      <p>
      This field shall contain the title of the text item.
@@ -41,6 +50,15 @@ public interface TextSegment extends CommonNitfSubSegment {
     String getTextTitle();
 
     /**
+     * Set text title.
+     * <p>
+     * This field shall contain the title of the text item.
+     *
+     * @param title text title (80 characters maximum).
+     */
+    void setTextTitle(final String title);
+
+    /**
      Return the text format indicator.
      <p>
      See TextFormat for the meaning of the enumerated values.
@@ -48,6 +66,15 @@ public interface TextSegment extends CommonNitfSubSegment {
      @return the text format
      */
     TextFormat getTextFormat();
+
+    /**
+     * Set the text format indicator.
+     * <p>
+     * See TextFormat for the meaning of the enumerated values.
+     *
+     * @param format the text format
+     */
+    void setTextFormat(final TextFormat format);
 
     /**
      * Get the text segment data string.

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentImpl.java
@@ -14,13 +14,13 @@
  */
 package org.codice.imaging.nitf.core.text;
 
-import org.codice.imaging.nitf.core.AbstractSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
 
 /**
  * Text segment information.
  */
-class TextSegmentImpl extends AbstractSubSegment implements TextSegment {
+class TextSegmentImpl extends CommonBasicSegmentImpl implements TextSegment {
 
     private NitfDateTime textDateTime = null;
     private String textTitle = null;
@@ -53,12 +53,9 @@ class TextSegmentImpl extends AbstractSubSegment implements TextSegment {
     }
 
     /**
-        Set text title.
-        <p>
-        This field shall contain the title of the text item.
-
-        @param title text title (80 characters maximum).
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setTextTitle(final String title) {
         textTitle = title;
     }
@@ -72,12 +69,9 @@ class TextSegmentImpl extends AbstractSubSegment implements TextSegment {
     }
 
     /**
-        Set the text format indicator.
-        <p>
-        See TextFormat for the meaning of the enumerated values.
-
-        @param format the text format
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setTextFormat(final TextFormat format) {
         textFormat = format;
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreParser.java
@@ -25,8 +25,8 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.Source;
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
 import org.codice.imaging.nitf.core.common.NitfReader;
+import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandler;
 import org.codice.imaging.nitf.core.schema.FieldType;
 import org.codice.imaging.nitf.core.schema.IfType;
 import org.codice.imaging.nitf.core.schema.LoopType;
@@ -300,15 +300,15 @@ public class TreParser {
     /**
      * Serialise out the TREs for the specified source.
      *
-     * @param header the header to read TREs from
+     * @param handler the TRE handler to read TREs from
      * @param source the source (which has to match the header) of the TREs.
      * @return byte array of serialised TREs - may be empty if there are no TREs.
      * @throws ParseException on TRE parsing problem.
      * @throws IOException on reading or writing problems.
      */
-    public final byte[] getTREs(final CommonNitfSegment header, final TreSource source) throws ParseException, IOException {
+    public final byte[] getTREs(final TaggedRecordExtensionHandler handler, final TreSource source) throws ParseException, IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        for (Tre tre : header.getTREsRawStructure().getTREsForSource(source)) {
+        for (Tre tre : handler.getTREsRawStructure().getTREsForSource(source)) {
             String name = padStringToLength(tre.getName(), TAG_LENGTH);
             baos.write(name.getBytes(StandardCharsets.UTF_8));
             if (tre.getRawData() != null) {

--- a/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
+++ b/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
@@ -33,7 +33,6 @@ import java.util.TreeMap;
 import org.codice.imaging.nitf.core.NitfFileHeader;
 import org.codice.imaging.nitf.core.NitfFileParser;
 import org.codice.imaging.nitf.core.SlottedNitfParseStrategy;
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
 import org.codice.imaging.nitf.core.common.FileReader;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfReader;
@@ -55,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import difflib.Delta;
 import difflib.DiffUtils;
 import difflib.Patch;
+import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandler;
 
 public class FileComparer {
     private static final Logger LOGGER = LoggerFactory.getLogger(FileComparer.class);
@@ -461,7 +461,7 @@ public class FileComparer {
         return (des1 != null) && (hasTREsOtherThanRPF(des1.getTREsRawStructure()));
     }
 
-    private void outputTresForSegment(CommonNitfSegment segment, String label) throws IOException {
+    private void outputTresForSegment(TaggedRecordExtensionHandler segment, String label) throws IOException {
         TreCollection treCollection = segment.getTREsRawStructure();
         for (Tre tre : treCollection.getTREs()) {
             if (tre.getRawData() == null) {

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/AbstractCommonSegmentNode.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/AbstractCommonSegmentNode.java
@@ -18,7 +18,7 @@ import java.awt.Color;
 
 import javax.swing.Action;
 
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
+import org.codice.imaging.nitf.core.common.CommonSegment;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -31,7 +31,7 @@ abstract class AbstractCommonSegmentNode extends AbstractNode {
     }
 
 
-    protected void addCommonSegmentProperties(final Sheet.Set set, final CommonNitfSegment segment) {
+    protected void addCommonSegmentProperties(final Sheet.Set set, final CommonSegment segment) {
         set.put(new StringProperty("identifier", "Segment Identifier", "Identifier for the segment.", segment.getIdentifier()));
         if (segment.getSecurityMetadata().getSecurityClassification() != null) {
             set.put(new StringProperty("securityClassification",

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/AbstractSegmentNode.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/AbstractSegmentNode.java
@@ -14,7 +14,7 @@
  */
 package org.codice.imaging.nitf.nitfnetbeansfiletype;
 
-import org.codice.imaging.nitf.core.common.CommonNitfSubSegment;
+import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 import org.openide.nodes.Children;
 import org.openide.nodes.Sheet;
 
@@ -25,7 +25,7 @@ abstract class AbstractSegmentNode extends AbstractCommonSegmentNode {
         super(children);
     }
 
-    protected void addSubSegmentProperties(final Sheet.Set set, final CommonNitfSubSegment segment) {
+    protected void addSubSegmentProperties(final Sheet.Set set, final CommonBasicSegment segment) {
         addCommonSegmentProperties(set, segment);
         set.put(new IntegerProperty("attachmentLevel",
                 "Attachment Level",

--- a/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/flow/NitfSegmentsFlow.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 
 import org.codice.imaging.nitf.core.NitfDataSource;
 import org.codice.imaging.nitf.core.NitfFileHeader;
-import org.codice.imaging.nitf.core.common.CommonNitfSegment;
+import org.codice.imaging.nitf.core.common.CommonSegment;
 import org.codice.imaging.nitf.core.dataextension.DataExtensionSegment;
 import org.codice.imaging.nitf.core.graphic.GraphicSegment;
 import org.codice.imaging.nitf.core.image.ImageSegment;
@@ -116,7 +116,7 @@ public class NitfSegmentsFlow {
         return forEachSegment(consumer, () -> mDataSource.getSymbolSegments());
     }
 
-    private <T extends CommonNitfSegment> NitfSegmentsFlow forEachSegment(Consumer<T> consumer, Supplier<List<T>> supplier) {
+    private <T extends CommonSegment> NitfSegmentsFlow forEachSegment(Consumer<T> consumer, Supplier<List<T>> supplier) {
         if (consumer != null && supplier != null) {
             List<T> segments = supplier.get();
 


### PR DESCRIPTION
Updated from original proposal, now uses "CommonBasicSegment" instead of "CommonNonExtensionSegment" for those segments other than Data Extension Segment (DES). Not the greatest naming, but the architecture is cleaner.

I added IMG-120 for the NitfFileHeader interface work.