### PR TITLE
[IMG-122] Protect against over-long string and byte arrays.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfFileHeaderWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfFileHeaderWriter.java
@@ -14,10 +14,10 @@
  */
 package org.codice.imaging.nitf.core;
 
-import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
+import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.dataextension.DataExtensionSegment;
 import org.codice.imaging.nitf.core.security.SecurityMetadataWriter;
@@ -50,11 +50,11 @@ public class NitfFileHeaderWriter extends AbstractSegmentWriter {
      */
     public final void writeFileHeader(final NitfDataSource mDataSource) throws IOException, ParseException {
         NitfFileHeader header = mDataSource.getNitfHeader();
-        mOutput.writeBytes(header.getFileType().getTextEquivalent());
+        writeBytes(header.getFileType().getTextEquivalent(), NitfConstants.FHDR_LENGTH + NitfConstants.FVER_LENGTH);
         writeFixedLengthNumber(header.getComplexityLevel(), NitfConstants.CLEVEL_LENGTH);
         writeFixedLengthString(header.getStandardType(), NitfConstants.STYPE_LENGTH);
         writeFixedLengthString(header.getOriginatingStationId(), NitfConstants.OSTAID_LENGTH);
-        mOutput.writeBytes(header.getFileDateTime().getSourceString());
+        writeDateTime(header.getFileDateTime());
         writeFixedLengthString(header.getFileTitle(), NitfConstants.FTITLE_LENGTH);
         SecurityMetadataWriter securityWriter = new SecurityMetadataWriter(mOutput, mTreParser);
         securityWriter.writeFileSecurityMetadata(header.getFileSecurityMetadata(), header.getFileType());
@@ -169,12 +169,12 @@ public class NitfFileHeaderWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(userDefinedHeaderDataLength, NitfConstants.UDHDL_LENGTH);
         if (userDefinedHeaderDataLength > 0) {
             writeFixedLengthNumber(header.getUserDefinedHeaderOverflow(), NitfConstants.UDHOFL_LENGTH);
-            mOutput.write(userDefinedHeaderData);
+            writeBytes(userDefinedHeaderData, userDefinedHeaderDataLength - NitfConstants.UDHOFL_LENGTH);
         }
         writeFixedLengthNumber(extendedHeaderDataLength, NitfConstants.XHDL_LENGTH);
         if (extendedHeaderDataLength > 0) {
             writeFixedLengthNumber(header.getExtendedHeaderDataOverflow(), NitfConstants.XHDLOFL_LENGTH);
-            mOutput.write(extendedHeaderData);
+            writeBytes(extendedHeaderData, extendedHeaderDataLength - NitfConstants.XHDLOFL_LENGTH);
         }
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
@@ -22,6 +22,8 @@ import org.codice.imaging.nitf.core.graphic.GraphicSegmentWriter;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityMetadataWriter;
 import org.codice.imaging.nitf.core.tre.TreParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Writer shared implementation details.
@@ -31,6 +33,8 @@ public abstract class AbstractSegmentWriter {
     private static final int ENCRYP_LENGTH = 1;
 
     private static final int KILOBYTE = 1024;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSegmentWriter.class);
 
     /**
      * Convenient buffer size for copying data.
@@ -66,6 +70,13 @@ public abstract class AbstractSegmentWriter {
         return String.format("%1$-" + length + "s", s);
     }
 
+    private String hyphenPadStringToLength(final String s, final int length) {
+        StringBuilder builder = new StringBuilder(s);
+        while (builder.length() < length) {
+            builder.append("-");
+        }
+        return builder.toString();
+    }
     /**
      * Write out the fixed field value for the ENCRYP field.
      *
@@ -76,14 +87,62 @@ public abstract class AbstractSegmentWriter {
     }
 
     /**
+     * Write out a string of specified fixed length.
+     *
+     * If the string is not the same as the specified length, an exception will
+     * be thrown.
+     *
+     * @param s the string to write
+     * @param length the length that the string should be.
+     * @throws IOException on writing problems.
+     */
+    protected final void writeBytes(final String s, final int length) throws IOException {
+        if (s.length() != length) {
+            String problem = String.format("String %s was not of expected length %d", s, length);
+            LOG.error(problem);
+            throw new IllegalArgumentException(problem);
+        }
+        mOutput.writeBytes(s);
+    }
+
+    /**
+     * Write out a byte array of specified fixed length.
+     *
+     * If the array is not the same as the specified length, an exception will
+     * be thrown.
+     *
+     * @param b the byte array to write
+     * @param length the length that the string should be.
+     * @throws IOException on writing problems.
+     */
+    protected final void writeBytes(final byte[] b, final int length) throws IOException {
+        if (b.length != length) {
+            String problem = String.format("Array was length %d, and not expected length %d", b.length, length);
+            LOG.error(problem);
+            throw new IllegalArgumentException(problem);
+        }
+        mOutput.write(b);
+    }
+
+    /**
      * Write out a string of fixed length, padding with spaces if necessary.
+     *
+     * If the string is longer than the specified length, it will be truncated,
+     * and the event logged.
      *
      * @param s the string to write
      * @param length the length that the string should be.
      * @throws IOException on writing problems.
      */
     protected final void writeFixedLengthString(final String s, final int length) throws IOException {
-        mOutput.writeBytes(padStringToLength(s, length));
+        String toWrite;
+        if (s.length() > length) {
+            LOG.warn(String.format("Truncated string \"%s\", max length is %d", s, length));
+            toWrite = s.substring(0, length);
+        } else {
+            toWrite = padStringToLength(s, length);
+        }
+        writeBytes(toWrite, length);
     }
 
     /**
@@ -92,9 +151,15 @@ public abstract class AbstractSegmentWriter {
      * @param number the number to write out.
      * @param length the length (number of characters) that the number should be.
      * @throws IOException on writing problems.
+     *
      */
     protected final void writeFixedLengthNumber(final long number, final int length) throws IOException {
-        mOutput.writeBytes(padNumberToLength(number, length));
+        if (String.format("%d", number).length() > length) {
+            String problem = String.format("Fixed length number %d cannot fit into length %d", number, length);
+            LOG.error(problem);
+            throw new NumberFormatException(problem);
+        }
+        writeBytes(padNumberToLength(number, length), length);
     }
 
     /**
@@ -113,11 +178,18 @@ public abstract class AbstractSegmentWriter {
     /**
      * Write out a NITF date-time.
      *
-     * @param textDateTime the date-time to write out.
+     * @param dateTime the date-time to write out.
      * @throws IOException on writing problems.
      */
-    protected final void writeDateTime(final NitfDateTime textDateTime) throws IOException {
-        writeFixedLengthString(textDateTime.getSourceString(), STANDARD_DATE_TIME_LENGTH);
+    protected final void writeDateTime(final NitfDateTime dateTime) throws IOException {
+        if (dateTime.getSourceString().length() == STANDARD_DATE_TIME_LENGTH) {
+            writeBytes(dateTime.getSourceString(), STANDARD_DATE_TIME_LENGTH);
+        } else if (dateTime.getSourceString().length() > STANDARD_DATE_TIME_LENGTH) {
+            LOG.warn(String.format("Invalid date format \"%s\"", dateTime.getSourceString()));
+            writeBytes(hyphenPadStringToLength("", STANDARD_DATE_TIME_LENGTH), STANDARD_DATE_TIME_LENGTH);
+        } else {
+            writeBytes(hyphenPadStringToLength(dateTime.getSourceString(), STANDARD_DATE_TIME_LENGTH), STANDARD_DATE_TIME_LENGTH);
+        }
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentWriter.java
@@ -85,7 +85,7 @@ public class GraphicSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(graphicExtendedSubheaderDataLength, SXSHDL_LENGTH);
         if (graphicExtendedSubheaderDataLength > 0) {
             writeFixedLengthNumber(graphicSegment.getExtendedHeaderDataOverflow(), SXSOFL_LENGTH);
-            mOutput.write(graphicExtendedSubheaderData);
+            writeBytes(graphicExtendedSubheaderData, graphicExtendedSubheaderDataLength - SXSOFL_LENGTH);
         }
         writeSegmentData(graphicSegment.getData());
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
@@ -144,7 +144,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
                 writeFixedLengthNumber(band.getNumLUTEntries(), NELUT_LENGTH);
                 for (int j = 0; j < band.getNumLUTs(); ++j) {
                     NitfImageBandLUT lut = band.getLUTZeroBase(j);
-                    mOutput.write(lut.getEntries());
+                    writeBytes(lut.getEntries(), band.getNumLUTEntries());
                 }
             }
         }
@@ -168,7 +168,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(userDefinedImageDataLength, UDIDL_LENGTH);
         if (userDefinedImageDataLength > 0) {
             writeFixedLengthNumber(imageSegment.getUserDefinedHeaderOverflow(), UDOFL_LENGTH);
-            mOutput.write(userDefinedImageData);
+            writeBytes(userDefinedImageData, userDefinedImageDataLength - UDOFL_LENGTH);
         }
         byte[] imageExtendedSubheaderData = mTreParser.getTREs(imageSegment, TreSource.ImageExtendedSubheaderData);
         int imageExtendedSubheaderDataLength = imageExtendedSubheaderData.length;
@@ -178,7 +178,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(imageExtendedSubheaderDataLength, IXSHDL_LENGTH);
         if (imageExtendedSubheaderDataLength > 0) {
             writeFixedLengthNumber(imageSegment.getExtendedHeaderDataOverflow(), IXSOFL_LENGTH);
-            mOutput.write(imageExtendedSubheaderData);
+            writeBytes(imageExtendedSubheaderData, imageExtendedSubheaderDataLength - IXSOFL_LENGTH);
         }
 
         writeSegmentData(imageSegment.getData());

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentWriter.java
@@ -17,6 +17,7 @@ package org.codice.imaging.nitf.core.label;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
+import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
 import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.label.LabelConstants.LA;
@@ -66,8 +67,8 @@ public class LabelSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(labelSegment.getAttachmentLevel(), LALVL_LENGTH);
         writeFixedLengthNumber(labelSegment.getLabelLocationRow(), LLOC_HALF_LENGTH);
         writeFixedLengthNumber(labelSegment.getLabelLocationColumn(), LLOC_HALF_LENGTH);
-        mOutput.write(labelSegment.getLabelTextColour().toByteArray());
-        mOutput.write(labelSegment.getLabelBackgroundColour().toByteArray());
+        writeBytes(labelSegment.getLabelTextColour().toByteArray(), RGBColour.RGB_COLOUR_LENGTH);
+        writeBytes(labelSegment.getLabelBackgroundColour().toByteArray(), RGBColour.RGB_COLOUR_LENGTH);
         byte[] labelExtendedSubheaderData = mTreParser.getTREs(labelSegment, TreSource.LabelExtendedSubheaderData);
         int labelExtendedSubheaderDataLength = labelExtendedSubheaderData.length;
         if ((labelExtendedSubheaderDataLength > 0) || (labelSegment.getExtendedHeaderDataOverflow() != 0)) {
@@ -76,7 +77,7 @@ public class LabelSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(labelExtendedSubheaderDataLength, LXSHDL_LENGTH);
         if (labelExtendedSubheaderDataLength > 0) {
             writeFixedLengthNumber(labelSegment.getExtendedHeaderDataOverflow(), LXSOFL_LENGTH);
-            mOutput.write(labelExtendedSubheaderData);
+            writeBytes(labelExtendedSubheaderData, labelExtendedSubheaderDataLength - LXSOFL_LENGTH);
         }
         mOutput.writeBytes(labelSegment.getData());
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentWriter.java
@@ -91,7 +91,7 @@ public class SymbolSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(symbolExtendedSubheaderDataLength, SXSHDL_LENGTH);
         if (symbolExtendedSubheaderDataLength > 0) {
             writeFixedLengthNumber(header.getExtendedHeaderDataOverflow(), SXSOFL_LENGTH);
-            mOutput.write(symbolExtendedSubheaderData);
+            writeBytes(symbolExtendedSubheaderData, symbolExtendedSubheaderDataLength - SXSOFL_LENGTH);
         }
         writeSegmentData(header.getData());
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentWriter.java
@@ -73,7 +73,7 @@ public class TextSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthNumber(textExtendedSubheaderDataLength, TXSHDL_LENGTH);
         if (textExtendedSubheaderDataLength > 0) {
             writeFixedLengthNumber(textSegment.getExtendedHeaderDataOverflow(), TXSOFL_LENGTH);
-            mOutput.write(textExtendedSubheaderData);
+            writeBytes(textExtendedSubheaderData, textExtendedSubheaderDataLength - TXSOFL_LENGTH);
         }
         mOutput.writeBytes(textSegment.getData());
     }

--- a/core/src/test/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriterTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriterTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.common;
+
+import java.io.DataOutput;
+import java.util.Arrays;
+import static org.hamcrest.Matchers.is;
+import org.junit.After;
+import static org.junit.Assert.assertThat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+
+/**
+ * Tests for shared writing code
+ */
+public class AbstractSegmentWriterTest {
+
+    private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(AbstractSegmentWriter.class);
+
+    public AbstractSegmentWriterTest() {
+    }
+
+    @After
+    public void clearLoggers() {
+        LOGGER.clear();
+    }
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testWriteENCRYP() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        testWriter.writeENCRYP();
+        verify(mockOutput).writeBytes("0");
+    }
+
+    @Test
+    public void testWriteFixedLengthString() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        testWriter.writeFixedLengthString("Test", 4);
+        verify(mockOutput).writeBytes("Test");
+
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+        testWriter.writeFixedLengthString("Too Long", 6);
+        verify(mockOutput).writeBytes("Too Lo");
+        assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
+                LoggingEvent.warn("Truncated string \"Too Long\", max length is 6"))));
+        LOGGER.clear();
+
+        testWriter.writeFixedLengthString("Short", 7);
+        verify(mockOutput).writeBytes("Short  ");
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+
+    }
+
+    @Test
+    public void testWriteFixedLengthNumber() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+
+        testWriter.writeFixedLengthNumber(3, 2);
+        verify(mockOutput).writeBytes("03");
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+
+        testWriter.writeFixedLengthNumber(23, 2);
+        verify(mockOutput).writeBytes("23");
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+
+        try {
+            exception.expect(IllegalArgumentException.class);
+            exception.expectMessage("Fixed length number 235 cannot fit into length 2");
+            testWriter.writeFixedLengthNumber(235, 2);
+        } finally {
+            assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
+                    LoggingEvent.error("Fixed length number 235 cannot fit into length 2"))));
+        }
+    }
+
+    @Test
+    public void testIncorrectStringLengthWrite() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+        try {
+            exception.expect(IllegalArgumentException.class);
+            exception.expectMessage("String Too Long was not of expected length 6");
+            testWriter.writeBytes("Too Long", 6);
+        } finally {
+            assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
+                    LoggingEvent.error("String Too Long was not of expected length 6"))));
+        }
+        verify(mockOutput, never()).writeBytes(any());
+        verify(mockOutput, never()).write(any());
+    }
+
+    @Test
+    public void testIncorrectByteArrayLengthWrite() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+        try {
+            exception.expect(IllegalArgumentException.class);
+            exception.expectMessage("Array was length 5, and not expected length 6");
+            testWriter.writeBytes(new byte[5], 6);
+        } finally {
+            assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
+                    LoggingEvent.error("Array was length 5, and not expected length 6"))));
+        }
+        verify(mockOutput, never()).writeBytes(any());
+        verify(mockOutput, never()).write(any());
+    }
+
+    @Test
+    public void testWriteDateTimeValidLength() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        NitfDateTime testDateTime = new NitfDateTime();
+        testDateTime.setSourceString("20160302021155");
+        testWriter.writeDateTime(testDateTime);
+        verify(mockOutput).writeBytes("20160302021155");
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testWriteDateTimeShortLength() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        NitfDateTime testDateTime = new NitfDateTime();
+        testDateTime.setSourceString("2016030202");
+        testWriter.writeDateTime(testDateTime);
+        verify(mockOutput).writeBytes("2016030202----");
+        assertThat(LOGGER.getLoggingEvents().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testWriteDateTimeLongLength() throws Exception {
+        DataOutput mockOutput = mock(DataOutput.class);
+        AbstractSegmentWriter testWriter = new AbstractSegmentWriterImpl(mockOutput);
+        NitfDateTime testDateTime = new NitfDateTime();
+        testDateTime.setSourceString("201603020211567");
+        testWriter.writeDateTime(testDateTime);
+        verify(mockOutput).writeBytes("--------------");
+        assertThat(LOGGER.getLoggingEvents(), is(Arrays.asList(
+                LoggingEvent.warn("Invalid date format \"201603020211567\""))));
+    }
+
+    public class AbstractSegmentWriterImpl extends AbstractSegmentWriter {
+
+        public AbstractSegmentWriterImpl(DataOutput output) {
+            super(output, null);
+        }
+    }
+
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/ImageBlock.java
@@ -21,6 +21,10 @@ import java.util.function.Supplier;
 
 /**
  * An ImageBlock represents a single block of a larger image.
+ *
+ * The concept is that the ImageBlock provides access to part of an underlying
+ * (supplied) image. The ImageBlock is effectively a window into an existing
+ * BufferedImage.
  */
 class ImageBlock {
 
@@ -33,10 +37,14 @@ class ImageBlock {
     private BufferedImage blockImage;
 
     /**
+     * Create a new image block with specified size and position.
      *
-     * @param row - the row position of this ImageBlock in the larger image.
-     * @param column - the column position of this ImageBlock in the larger image.
+     * @param row the row position of this ImageBlock in the larger image.
+     * @param column the column position of this ImageBlock in the larger image.
      * @param numColumns the number of columns in the ImageBlock.
+     * @param width the width of this block in pixels.
+     * @param height the height of this block in pixels.
+     * @param imageSupplier the Supplier of the underlying image to draw into.
      */
     public ImageBlock(int row, int column, int numColumns, int width, int height,
             Supplier<BufferedImage> imageSupplier) {
@@ -49,6 +57,7 @@ class ImageBlock {
     }
 
     /**
+     * Get the data buffer for this block.
      *
      * @return the DataBuffer that contains the data for this ImageBlock.
      */
@@ -60,6 +69,13 @@ class ImageBlock {
         return blockImage.getRaster().getDataBuffer();
     }
 
+    /**
+     * Render this image block into a target image.
+     *
+     * @param targetImage the image to draw into.
+     * @param disposeAfterRender set to true if this block should be disposed of
+     * after the rendering is complete.
+     */
     public void render(Graphics2D targetImage, boolean disposeAfterRender) {
         targetImage.drawImage(blockImage, this.column * this.height, this.row * this.width, null);
 
@@ -68,10 +84,20 @@ class ImageBlock {
         }
     }
 
+    /**
+     * Get the width of this image block.
+     *
+     * @return the width (x dimension) of the block in pixels.
+     */
     public int getWidth() {
         return width;
     }
 
+    /**
+     * Get the height of this image block.
+     *
+     * @return the height (y dimension) of the block in pixels.
+     */
     public int getHeight() {
         return height;
     }


### PR DESCRIPTION
The logic is that for "normal" strings, we will pad or truncate as needed.

For numbers, we'll zero pad, but if the number is too long to fit, we'll throw an
exception, because that would otherwise result in a (silently) corrupted file.

The exception also applies for strings and byte arrays that are supposed to be of
known length (because that will also result in corrupted file, and likely indicates
an implementation problem.