### PR TITLE
[IMG-123] Update the TRE structure for J2KLRA.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ hs_err_pid*
 *.iml
 
 .idea/
+/core/nbproject/

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -433,11 +433,31 @@
             <field name="LAYER_ID" length="3"/>
             <field name="BITRATE" length="9"/>
         </loop>
-        <if_remaining_bytes>
+        <if cond="ORIG=1">
             <field name="NLEVELS_I" length="2"/>
             <field name="NBANDS_I" length="5"/>
             <field name="NLAYERS_I" length="3"/>
-        </if_remaining_bytes>
+        </if>
+        <if cond="ORIG=3">
+            <field name="NLEVELS_I" length="2"/>
+            <field name="NBANDS_I" length="5"/>
+            <field name="NLAYERS_I" length="3"/>
+        </if>
+        <if cond="ORIG=5">
+            <field name="NLEVELS_I" length="2"/>
+            <field name="NBANDS_I" length="5"/>
+            <field name="NLAYERS_I" length="3"/>
+        </if>
+        <if cond="ORIG=7">
+            <field name="NLEVELS_I" length="2"/>
+            <field name="NBANDS_I" length="5"/>
+            <field name="NLAYERS_I" length="3"/>
+        </if>
+        <if cond="ORIG=9">
+            <field name="NLEVELS_I" length="2"/>
+            <field name="NBANDS_I" length="5"/>
+            <field name="NLAYERS_I" length="3"/>
+        </if>
     </tre>
 
     <tre name="MAPLOB" length="43" location="image">

--- a/core/src/main/xsd/nitf_spec.xsd
+++ b/core/src/main/xsd/nitf_spec.xsd
@@ -65,7 +65,6 @@
                 </xs:element>
                 <xs:element name="if" type="ifType"/>
             </xs:choice>
-            <xs:element name="if_remaining_bytes" type="if_remaining_bytesType" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:group>
 
@@ -111,10 +110,6 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="if_remaining_bytesType">
-        <xs:group ref="itemType"/>
     </xs:complexType>
 
     <xs:complexType name="fieldType">

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/ENGRDA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/ENGRDA_Test.java
@@ -12,12 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.tre;
 
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.util.List;
+import org.codice.imaging.nitf.core.AllDataExtractionParseStrategy;
+import org.codice.imaging.nitf.core.NitfFileHeader;
+import org.codice.imaging.nitf.core.NitfFileParser;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.image.ImageSegment;
@@ -27,13 +30,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * This checks the parsing of ENGRDA TRE.
  */
-public class ENGRDATest {
+public class ENGRDA_Test {
 
-    public ENGRDATest() {
+    public ENGRDA_Test() {
     }
 
     @Test

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/J2KLRA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/J2KLRA_Test.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.List;
+import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.common.NitfReader;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ * Tests for J2KLRA TRE parsing.
+ */
+public class J2KLRA_Test {
+
+    public J2KLRA_Test() {
+    }
+
+    @Test
+    public void BasicJ2KLRA() throws Exception {
+        InputStream inputStream = new ByteArrayInputStream("J2KLRA002390050000101900000.03125000100.06250000200.12500000300.25000000400.50000000500.60000000600.70000000700.80000000800.90000000901.00000001001.10000001101.20000001201.30000001301.50000001401.70000001502.00000001602.30000001703.50000001803.900000".getBytes());
+        BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        TreCollection parseResult = parser.parse(nitfReader, 250, TreSource.ImageExtendedSubheaderData);
+        assertEquals(1, parseResult.getTREs().size());
+        Tre j2klra = parseResult.getTREsWithName("J2KLRA").get(0);
+        assertNotNull(j2klra);
+        assertEquals(5, j2klra.getEntries().size());
+        assertEquals("0", j2klra.getFieldValue("ORIG"));
+        assertEquals("05", j2klra.getFieldValue("NLEVELS_O"));
+        assertEquals("00001", j2klra.getFieldValue("NBANDS_O"));
+        assertEquals("019", j2klra.getFieldValue("NLAYERS_O"));
+
+        TreEntry layer = j2klra.getEntry("LAYER");
+        assertNotNull(layer);
+        List<TreGroup> layerGroups = layer.getGroups();
+        assertNotNull(layerGroups);
+        assertEquals(19, layerGroups.size());
+
+        TreGroup layerGroup0 = layerGroups.get(0);
+        assertNotNull(layerGroup0);
+        assertEquals("000", layerGroup0.getFieldValue("LAYER_ID"));
+        assertEquals("00.031250", layerGroup0.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup1 = layerGroups.get(1);
+        assertNotNull(layerGroup1);
+        assertEquals("001", layerGroup1.getFieldValue("LAYER_ID"));
+        assertEquals("00.062500", layerGroup1.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup10 = layerGroups.get(10);
+        assertNotNull(layerGroup10);
+        assertEquals("010", layerGroup10.getFieldValue("LAYER_ID"));
+        assertEquals("01.100000", layerGroup10.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup17 = layerGroups.get(17);
+        assertNotNull(layerGroup17);
+        assertEquals("017", layerGroup17.getFieldValue("LAYER_ID"));
+        assertEquals("03.500000", layerGroup17.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup18 = layerGroups.get(18);
+        assertNotNull(layerGroup18);
+        assertEquals("018", layerGroup18.getFieldValue("LAYER_ID"));
+        assertEquals("03.900000", layerGroup18.getFieldValue("BITRATE"));
+    }
+
+    @Test
+    public void ReprocessedJ2KLRA() throws Exception {
+        InputStream inputStream = new ByteArrayInputStream("J2KLRA002493050000101900000.03125000100.06250000200.12500000300.25000000400.50000000500.60000000600.70000000700.80000000800.90000000901.00000001001.10000001101.20000001201.30000001301.50000001401.70000001502.00000001602.30000001703.50000001803.9000000000001011".getBytes());
+        BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        TreCollection parseResult = parser.parse(nitfReader, 250, TreSource.ImageExtendedSubheaderData);
+        assertEquals(1, parseResult.getTREs().size());
+        Tre j2klra = parseResult.getTREsWithName("J2KLRA").get(0);
+        assertNotNull(j2klra);
+        assertEquals(8, j2klra.getEntries().size());
+        assertEquals("3", j2klra.getFieldValue("ORIG"));
+        assertEquals("05", j2klra.getFieldValue("NLEVELS_O"));
+        assertEquals("00001", j2klra.getFieldValue("NBANDS_O"));
+        assertEquals("019", j2klra.getFieldValue("NLAYERS_O"));
+
+        TreEntry layer = j2klra.getEntry("LAYER");
+        assertNotNull(layer);
+        List<TreGroup> layerGroups = layer.getGroups();
+        assertNotNull(layerGroups);
+        assertEquals(19, layerGroups.size());
+
+        TreGroup layerGroup0 = layerGroups.get(0);
+        assertNotNull(layerGroup0);
+        assertEquals("000", layerGroup0.getFieldValue("LAYER_ID"));
+        assertEquals("00.031250", layerGroup0.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup1 = layerGroups.get(1);
+        assertNotNull(layerGroup1);
+        assertEquals("001", layerGroup1.getFieldValue("LAYER_ID"));
+        assertEquals("00.062500", layerGroup1.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup10 = layerGroups.get(10);
+        assertNotNull(layerGroup10);
+        assertEquals("010", layerGroup10.getFieldValue("LAYER_ID"));
+        assertEquals("01.100000", layerGroup10.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup17 = layerGroups.get(17);
+        assertNotNull(layerGroup17);
+        assertEquals("017", layerGroup17.getFieldValue("LAYER_ID"));
+        assertEquals("03.500000", layerGroup17.getFieldValue("BITRATE"));
+
+        TreGroup layerGroup18 = layerGroups.get(18);
+        assertNotNull(layerGroup18);
+        assertEquals("018", layerGroup18.getFieldValue("LAYER_ID"));
+        assertEquals("03.900000", layerGroup18.getFieldValue("BITRATE"));
+
+        assertEquals("00", j2klra.getFieldValue("NLEVELS_I"));
+        assertEquals("00001", j2klra.getFieldValue("NBANDS_I"));
+        assertEquals("011", j2klra.getFieldValue("NLAYERS_I"));
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/SENSRB_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/SENSRB_Test.java
@@ -12,7 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  */
-package org.codice.imaging.nitf.core;
+package org.codice.imaging.nitf.core.tre;
 
 import org.codice.imaging.nitf.core.tre.TreSource;
 import java.io.BufferedInputStream;
@@ -30,8 +30,10 @@ import org.codice.imaging.nitf.core.tre.TreGroup;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-public class SensrbTest {
+public class SENSRB_Test {
 
     // Has 1, 5, 6
     @Test


### PR DESCRIPTION
Also moves in a couple of other TRE tests into the same test module. This is for
consistency and possibly some future refactoring.