### PR TITLE
[IMG-92] Remove Nitf prefix on image classes.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBand.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBand.java
@@ -20,18 +20,18 @@ import java.util.List;
 /**
     Image Band.
 */
-public class NitfImageBand {
+public class ImageBand {
 
     // An enum might have been useful, but this is extensible
     private String imageRepresentation = null;
     private String imageSubcategory = null;
     private int numEntriesLUT = 0;
-    private List<NitfImageBandLUT> luts = new ArrayList<NitfImageBandLUT>();
+    private List<ImageBandLUT> luts = new ArrayList<ImageBandLUT>();
 
     /**
         Default constructor.
     */
-    public NitfImageBand() {
+    public ImageBand() {
     }
 
     /**
@@ -153,7 +153,7 @@ public class NitfImageBand {
 
         @param lut the lookup table to add.
     */
-    public final void addLUT(final NitfImageBandLUT lut) {
+    public final void addLUT(final ImageBandLUT lut) {
         luts.add(lut);
     }
 
@@ -163,7 +163,7 @@ public class NitfImageBand {
         @param lutNumber the index of the lookup table (1-base).
         @return the lookup table corresponding to the index.
     */
-    public final NitfImageBandLUT getLUT(final int lutNumber) {
+    public final ImageBandLUT getLUT(final int lutNumber) {
         return getLUTZeroBase(lutNumber - 1);
     }
 
@@ -173,7 +173,7 @@ public class NitfImageBand {
         @param lutNumberZeroBase the index of the lookup table (0-base).
         @return the lookup table corresponding to the index.
     */
-    public final NitfImageBandLUT getLUTZeroBase(final int lutNumberZeroBase) {
+    public final ImageBandLUT getLUTZeroBase(final int lutNumberZeroBase) {
         return luts.get(lutNumberZeroBase);
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBandLUT.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBandLUT.java
@@ -17,7 +17,7 @@ package org.codice.imaging.nitf.core.image;
 /**
     Lookup table for an image band.
 */
-public class NitfImageBandLUT {
+public class ImageBandLUT {
 
     private byte[] entries = null;
 
@@ -26,7 +26,7 @@ public class NitfImageBandLUT {
 
         @param lutEntries the LUT data, in order.
     */
-    public NitfImageBandLUT(final byte[] lutEntries) {
+    public ImageBandLUT(final byte[] lutEntries) {
         entries = lutEntries;
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBandParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageBandParser.java
@@ -26,10 +26,10 @@ import static org.codice.imaging.nitf.core.image.ImageConstants.NLUTS_LENGTH;
 /**
     Image Band and Image Band LUT parser.
 */
-class NitfImageBandParser {
+class ImageBandParser {
 
     private NitfReader reader = null;
-    private NitfImageBand imageBand = null;
+    private ImageBand imageBand = null;
     private int numLUTs = 0;
 
     /**
@@ -39,7 +39,7 @@ class NitfImageBandParser {
         @throws ParseException if an obviously invalid value is detected during parsing,
         or if another problem occurs during parsing (e.g. end of file).
     */
-    NitfImageBandParser(final NitfReader nitfReader, final NitfImageBand band) throws ParseException {
+    ImageBandParser(final NitfReader nitfReader, final ImageBand band) throws ParseException {
         reader = nitfReader;
         imageBand = band;
         readIREPBAND();
@@ -50,7 +50,7 @@ class NitfImageBandParser {
         if (numLUTs > 0) {
             readNELUT();
             for (int i = 0; i < numLUTs; ++i) {
-                NitfImageBandLUT lut = new NitfImageBandLUT(reader.readBytesRaw(imageBand.getNumLUTEntries()));
+                ImageBandLUT lut = new ImageBandLUT(reader.readBytesRaw(imageBand.getNumLUTEntries()));
                 imageBand.addLUT(lut);
             }
         }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
@@ -323,7 +323,7 @@ public interface ImageSegment extends CommonBasicSegment {
      @param bandNumber the index of the band to return.
      @return image band corresponding to the bandNumber index
      */
-    NitfImageBand getImageBand(int bandNumber);
+    ImageBand getImageBand(int bandNumber);
 
     /**
      Return the image band (zero base).
@@ -334,7 +334,7 @@ public interface ImageSegment extends CommonBasicSegment {
      @param bandNumberZeroBase the index of the band to return (0 base).
      @return image band corresponding to the bandNumberZeroBase index
      */
-    NitfImageBand getImageBandZeroBase(int bandNumberZeroBase);
+    ImageBand getImageBandZeroBase(int bandNumberZeroBase);
 
     /**
      Return the image mode (IMODE) for the image.

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentImpl.java
@@ -41,7 +41,7 @@ class ImageSegmentImpl extends CommonBasicSegmentImpl implements ImageSegment {
     private final List<String> imageComments = new ArrayList<>();
     private ImageCompression imageCompression = ImageCompression.UNKNOWN;
     private String compressionRate = null;
-    private final List<NitfImageBand> imageBands = new ArrayList<>();
+    private final List<ImageBand> imageBands = new ArrayList<>();
     private ImageMode imageMode = ImageMode.UNKNOWN;
     private int numBlocksPerRow = 0;
     private int numBlocksPerColumn = 0;
@@ -536,7 +536,7 @@ class ImageSegmentImpl extends CommonBasicSegmentImpl implements ImageSegment {
 
         @param imageBand the image band to add
     */
-    public final void addImageBand(final NitfImageBand imageBand) {
+    public final void addImageBand(final ImageBand imageBand) {
         imageBands.add(imageBand);
     }
 
@@ -544,7 +544,7 @@ class ImageSegmentImpl extends CommonBasicSegmentImpl implements ImageSegment {
      * {@inheritDoc}
      */
     @Override
-    public final NitfImageBand getImageBand(final int bandNumber) {
+    public final ImageBand getImageBand(final int bandNumber) {
         return getImageBandZeroBase(bandNumber - 1);
     }
 
@@ -552,7 +552,7 @@ class ImageSegmentImpl extends CommonBasicSegmentImpl implements ImageSegment {
      * {@inheritDoc}
      */
     @Override
-    public final NitfImageBand getImageBandZeroBase(final int bandNumberZeroBase) {
+    public final ImageBand getImageBandZeroBase(final int bandNumberZeroBase) {
         return imageBands.get(bandNumberZeroBase);
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentParser.java
@@ -132,8 +132,8 @@ public class ImageSegmentParser extends AbstractSegmentParser {
             readXBANDS();
         }
         for (int i = 0; i < numBands; ++i) {
-            NitfImageBand imageBand = new NitfImageBand();
-            new NitfImageBandParser(reader, imageBand);
+            ImageBand imageBand = new ImageBand();
+            new ImageBandParser(reader, imageBand);
             segment.addImageBand(imageBand);
         }
         readISYNC();

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
@@ -134,7 +134,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
         }
 
         for (int i = 0; i < imageSegment.getNumBands(); ++i) {
-            NitfImageBand band = imageSegment.getImageBandZeroBase(i);
+            ImageBand band = imageSegment.getImageBandZeroBase(i);
             writeFixedLengthString(band.getImageRepresentation(), IREPBAND_LENGTH);
             writeFixedLengthString(band.getSubCategory(), ISUBCAT_LENGTH);
             writeFixedLengthString("N", IFC_LENGTH);
@@ -143,7 +143,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
             if (band.getNumLUTs() != 0) {
                 writeFixedLengthNumber(band.getNumLUTEntries(), NELUT_LENGTH);
                 for (int j = 0; j < band.getNumLUTs(); ++j) {
-                    NitfImageBandLUT lut = band.getLUTZeroBase(j);
+                    ImageBandLUT lut = band.getLUTZeroBase(j);
                     writeBytes(lut.getEntries(), band.getNumLUTEntries());
                 }
             }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
@@ -29,7 +29,7 @@ import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
+import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
@@ -176,7 +176,7 @@ public class Nitf20HeaderTest {
         assertEquals(0, imageSegment1.getImageComments().size());
         assertEquals(ImageCompression.NOTCOMPRESSED, imageSegment1.getImageCompression());
         assertEquals(1, imageSegment1.getNumBands());
-        NitfImageBand band1 = imageSegment1.getImageBand(1);
+        ImageBand band1 = imageSegment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
@@ -28,7 +28,7 @@ import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
+import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
@@ -112,7 +112,7 @@ public class Nitf20OverflowTest {
         assertEquals(0, imageSegment1.getImageComments().size());
         assertEquals(ImageCompression.NOTCOMPRESSED, imageSegment1.getImageCompression());
         assertEquals(1, imageSegment1.getNumBands());
-        NitfImageBand band1 = imageSegment1.getImageBand(1);
+        ImageBand band1 = imageSegment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -48,8 +48,8 @@ import org.codice.imaging.nitf.core.image.ImageCoordinates;
 import org.codice.imaging.nitf.core.image.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
-import org.codice.imaging.nitf.core.image.NitfImageBandLUT;
+import org.codice.imaging.nitf.core.image.ImageBand;
+import org.codice.imaging.nitf.core.image.ImageBandLUT;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
@@ -152,24 +152,24 @@ public class Nitf21HeaderTest {
         assertEquals(1, segment1.getNumBands());
 
         // Checks for ImageBand
-        NitfImageBand band1 = segment1.getImageBand(1);
+        ImageBand band1 = segment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("LU", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());
         assertEquals(3, band1.getNumLUTs());
         assertEquals(2, band1.getNumLUTEntries());
         // Checks for lookup tables
-        NitfImageBandLUT lut1 = band1.getLUT(1);
+        ImageBandLUT lut1 = band1.getLUT(1);
         assertNotNull(lut1);
         assertEquals(2, lut1.getNumberOfEntries());
         assertEquals((byte)0xFF, lut1.getEntry(0));
         assertEquals((byte)0x00, lut1.getEntry(1));
-        NitfImageBandLUT lut2 = band1.getLUT(2);
+        ImageBandLUT lut2 = band1.getLUT(2);
         assertNotNull(lut2);
         assertEquals(2, lut2.getNumberOfEntries());
         assertEquals((byte)0x00, lut2.getEntry(0));
         assertEquals((byte)0xFF, lut2.getEntry(1));
-        NitfImageBandLUT lut3 = band1.getLUT(3);
+        ImageBandLUT lut3 = band1.getLUT(3);
         assertNotNull(lut3);
         assertEquals(2, lut3.getNumberOfEntries());
         assertEquals((byte)0x00, lut3.getEntry(0));
@@ -251,7 +251,7 @@ public class Nitf21HeaderTest {
         assertEquals(ImageCompression.NOTCOMPRESSED, segment1.getImageCompression());
         assertEquals(1, segment1.getNumBands());
         // Checks for ImageBand
-        NitfImageBand band1 = segment1.getImageBand(1);
+        ImageBand band1 = segment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("M", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());
@@ -322,7 +322,7 @@ public class Nitf21HeaderTest {
         assertEquals(ImageCompression.JPEG, segment1.getImageCompression());
         assertEquals("00.0", segment1.getCompressionRate());
         assertEquals(1, segment1.getNumBands());
-        NitfImageBand band1 = segment1.getImageBand(1);
+        ImageBand band1 = segment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("M", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());
@@ -425,7 +425,7 @@ public class Nitf21HeaderTest {
         assertEquals(0, segment2.getImageComments().size());
         assertEquals(ImageCompression.NOTCOMPRESSED, segment2.getImageCompression());
         assertEquals(1, segment2.getNumBands());
-        NitfImageBand band1 = segment1.getImageBand(1);
+        ImageBand band1 = segment1.getImageBand(1);
         assertNotNull(band1);
         assertEquals("M", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());
@@ -923,7 +923,7 @@ public class Nitf21HeaderTest {
         assertEquals("", imageSegment.getImageComments().get(2));
         assertEquals(ImageCompression.NOTCOMPRESSED, imageSegment.getImageCompression());
         assertEquals(1, imageSegment.getNumBands());
-        NitfImageBand band1 = imageSegment.getImageBand(1);
+        ImageBand band1 = imageSegment.getImageBand(1);
         assertNotNull(band1);
         assertEquals("M", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
@@ -28,7 +28,7 @@ import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageCoordinatesRepresentation;
 import org.codice.imaging.nitf.core.image.ImageMode;
 import org.codice.imaging.nitf.core.image.ImageRepresentation;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
+import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
@@ -87,19 +87,19 @@ public class Nitf21SorcerTest {
         assertEquals(3, imageSegment.getNumBands());
 
         // Checks for ImageBand
-        NitfImageBand band1 = imageSegment.getImageBand(1);
+        ImageBand band1 = imageSegment.getImageBand(1);
         assertNotNull(band1);
         assertEquals("Y", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());
         assertEquals(0, band1.getNumLUTs());
         assertEquals(0, band1.getNumLUTEntries());
-        NitfImageBand band2 = imageSegment.getImageBand(2);
+        ImageBand band2 = imageSegment.getImageBand(2);
         assertNotNull(band2);
         assertEquals("Cb", band2.getImageRepresentation());
         assertEquals("", band2.getSubCategory());
         assertEquals(0, band2.getNumLUTs());
         assertEquals(0, band2.getNumLUTEntries());
-        NitfImageBand band3 = imageSegment.getImageBand(3);
+        ImageBand band3 = imageSegment.getImageBand(3);
         assertNotNull(band3);
         assertEquals("Cr", band3.getImageRepresentation());
         assertEquals("", band3.getSubCategory());

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/Nitf21ImageParsingTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/Nitf21ImageParsingTest.java
@@ -93,7 +93,7 @@ public class Nitf21ImageParsingTest {
         assertEquals(0, imageSegment.getImageComments().size());
         assertEquals(ImageCompression.NOTCOMPRESSED, imageSegment.getImageCompression());
         assertEquals(1, imageSegment.getNumBands());
-        NitfImageBand band1 = imageSegment.getImageBand(1);
+        ImageBand band1 = imageSegment.getImageBand(1);
         assertNotNull(band1);
         assertEquals("M", band1.getImageRepresentation());
         assertEquals("", band1.getSubCategory());

--- a/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfImageSegmentNode.java
+++ b/nitfNetbeansFileType/src/main/java/org/codice/imaging/nitf/nitfnetbeansfiletype/NitfImageSegmentNode.java
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter;
 import javax.imageio.stream.ImageInputStream;
 import javax.swing.Action;
 import javax.swing.tree.TreeModel;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
+import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.openide.nodes.Children;
 import org.openide.nodes.Sheet;
@@ -172,7 +172,7 @@ class NitfImageSegmentNode extends AbstractSegmentNode {
     }
 
     private void addImageBandSetToSheet(final int bandNumber, final Sheet sheet) {
-        NitfImageBand band = header.getImageBandZeroBase(bandNumber);
+        ImageBand band = header.getImageBandZeroBase(bandNumber);
         Sheet.Set bandProperties = Sheet.createPropertiesSet();
         bandProperties.setName("imageBand" + bandNumber);
         bandProperties.setDisplayName(String.format("Image Band %d", bandNumber));

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -17,7 +17,7 @@ package org.codice.imaging.nitf.render.imagerep;
 import java.util.HashMap;
 import java.util.Map;
 import org.codice.imaging.nitf.core.image.ImageSegment;
-import org.codice.imaging.nitf.core.image.NitfImageBand;
+import org.codice.imaging.nitf.core.image.ImageBand;
 import org.codice.imaging.nitf.render.datareader.DataReaderFactory;
 import org.codice.imaging.nitf.render.datareader.IOReaderFunction;
 
@@ -112,7 +112,7 @@ public final class ImageRepresentationHandlerFactory {
         boolean hasG = false;
         boolean hasB = false;
         for (int i = 0; i < segment.getNumBands(); i++) {
-            NitfImageBand band = segment.getImageBandZeroBase(i);
+            ImageBand band = segment.getImageBandZeroBase(i);
             if (null != band.getImageRepresentation()) {
                 switch (band.getImageRepresentation()) {
                     case "R":
@@ -134,7 +134,7 @@ public final class ImageRepresentationHandlerFactory {
 
     private static int getFirstMonoBandZeroBase(final ImageSegment segment) {
         for (int bandIndex = 0; bandIndex < segment.getNumBands(); bandIndex++) {
-            NitfImageBand band = segment.getImageBandZeroBase(bandIndex);
+            ImageBand band = segment.getImageBandZeroBase(bandIndex);
             if (null != band.getImageRepresentation() && ("M".equals(band.getImageRepresentation()))) {
                 return bandIndex;
             }
@@ -144,7 +144,7 @@ public final class ImageRepresentationHandlerFactory {
 
     private static int getFirstLookupBandZeroBase(final ImageSegment segment) {
         for (int bandIndex = 0; bandIndex < segment.getNumBands(); bandIndex++) {
-            NitfImageBand band = segment.getImageBandZeroBase(bandIndex);
+            ImageBand band = segment.getImageBandZeroBase(bandIndex);
             if (null != band.getImageRepresentation() && ("LU".equals(band.getImageRepresentation()))) {
                 return bandIndex;
             }


### PR DESCRIPTION
This renames NitfImageBand, NitfImageBandLUT and NitfImageBandParser. The other changes
are to match the refactoring.