### PR TITLE
[IMG-126] Add support for creating text segments, and updating header lengths on write.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/AllDataExtractionParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/AllDataExtractionParseStrategy.java
@@ -25,47 +25,47 @@ public class AllDataExtractionParseStrategy extends SlottedNitfParseStrategy {
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, true));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, true, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, true));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, true, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, true));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, true));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, i, true));
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, true, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, true));
+    public final void handleTextSegment(final NitfReader reader, final long len) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, len, true));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, true));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, true, dataLength));
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/HeaderOnlyNitfParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/HeaderOnlyNitfParseStrategy.java
@@ -26,47 +26,47 @@ public class HeaderOnlyNitfParseStrategy extends SlottedNitfParseStrategy {
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, false));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, false));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, false));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, i, false));
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, false));
+    public final void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, false));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, false, dataLength));
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractSegmentWriter {
 
-    private static final int ENCRYP_LENGTH = 1;
-
     private static final int KILOBYTE = 1024;
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractSegmentWriter.class);
@@ -83,7 +81,7 @@ public abstract class AbstractSegmentWriter {
      * @throws IOException on writing failure.
      */
     protected final void writeENCRYP() throws IOException {
-        writeFixedLengthString("0", ENCRYP_LENGTH);
+        writeFixedLengthString("0", CommonConstants.ENCRYP_LENGTH);
     }
 
     /**
@@ -166,13 +164,12 @@ public abstract class AbstractSegmentWriter {
      * Write out the segment-level security metadata.
      *
      * @param securityMetadata security data for the segment.
-     * @param fileType the type (NITF version) of security data to write out.
      * @throws IOException on writing problems.
      */
-    protected final void writeSecurityMetadata(final SecurityMetadata securityMetadata, final FileType fileType) throws IOException {
+    protected final void writeSecurityMetadata(final SecurityMetadata securityMetadata) throws IOException {
         // TODO: consider making this a member variable. Requires restructing SecurityMetadataWriter and probably writer code
         SecurityMetadataWriter securityMetadataWriter = new SecurityMetadataWriter(mOutput, mTreParser);
-        securityMetadataWriter.writeMetadata(securityMetadata, fileType);
+        securityMetadataWriter.writeMetadata(securityMetadata);
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonConstants.java
@@ -17,20 +17,20 @@ package org.codice.imaging.nitf.core.common;
 /**
  * Constants used by classes within the 'common' package.
  */
-final class CommonConstants {
+public final class CommonConstants {
 
     /**
      * Length of the "ENCRYP" field used in multiple headers.
      * <p>
      * See, for example, MIL-STD-2500C Table A-1.
      */
-    static final int ENCRYP_LENGTH = 1;
+    public static final int ENCRYP_LENGTH = 1;
 
     // Dates
     /**
      * The length of a "proper" formatted date.
      */
-    static final int STANDARD_DATE_TIME_LENGTH = 14;
+    public static final int STANDARD_DATE_TIME_LENGTH = 14;
 
     /**
      * The date format used by NITF 2.1.

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegment.java
@@ -14,6 +14,8 @@
  */
 package org.codice.imaging.nitf.core.common;
 
+import java.io.IOException;
+import java.text.ParseException;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 
 /**
@@ -31,7 +33,10 @@ public interface CommonSegment extends TaggedRecordExtensionHandler {
      * This field shall contain a valid alphanumeric identification code associated with the segment. The valid codes
      * are determined by the application.
      *
-     * @return the identifier
+     * This is a fixed length field in the segment, and any space padding will be included in the result. You may wish
+     * to trim() the result before displaying or storing this field content.
+     *
+     * @return the identifier, including any space padding.
      */
     String getIdentifier();
 
@@ -61,5 +66,14 @@ public interface CommonSegment extends TaggedRecordExtensionHandler {
      */
     void setSecurityMetadata(final SecurityMetadata metaData);
 
+    /**
+     * Get the length of this segment, excluding the data.
+     *
+     * @return actual header length in bytes.
+     *
+     * @throws java.text.ParseException if the underlying data length could not be calculated
+     * @throws java.io.IOException if there was a problem reading configuration data
+     */
+    long getHeaderLength() throws ParseException, IOException;
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/CommonSegmentImpl.java
@@ -22,7 +22,7 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  * This includes image segments, symbol segments, graphic segments, label segments, text segments and data extension
  * segments.
  */
-public class CommonSegmentImpl extends TaggedRecordExtensionHandlerImpl implements CommonSegment {
+public abstract class CommonSegmentImpl extends TaggedRecordExtensionHandlerImpl implements CommonSegment {
 
     private String segmentIdentifier;
     private SecurityMetadata securityMetadata = null;
@@ -30,6 +30,7 @@ public class CommonSegmentImpl extends TaggedRecordExtensionHandlerImpl implemen
     /**
      * {@inheritDoc}
      */
+    @Override
     public final void setIdentifier(final String identifier) {
         segmentIdentifier = identifier;
     }
@@ -57,6 +58,4 @@ public class CommonSegmentImpl extends TaggedRecordExtensionHandlerImpl implemen
     public final SecurityMetadata getSecurityMetadata() {
         return securityMetadata;
     }
-
-
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/NitfParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/NitfParseStrategy.java
@@ -14,8 +14,8 @@
  */
 package org.codice.imaging.nitf.core.common;
 
-import org.codice.imaging.nitf.core.header.NitfHeader;
 import java.text.ParseException;
+import org.codice.imaging.nitf.core.header.NitfHeader;
 import org.codice.imaging.nitf.core.tre.TreCollection;
 import org.codice.imaging.nitf.core.tre.TreSource;
 
@@ -39,13 +39,6 @@ public interface NitfParseStrategy {
     NitfHeader getNitfHeader();
 
     /**
-     * Indication that the "base" file-level headers have been read.
-     *
-     * @param reader the reader, positioned for reading of the segments
-     */
-    void baseHeadersRead(NitfReader reader);
-
-    /**
      * Parse and return the TREs.
      *
      * @param reader the reader to read the TRE data from
@@ -56,5 +49,59 @@ public interface NitfParseStrategy {
      * @throws java.text.ParseException if there is a problem loading the TRE descriptions, or in parsing TREs.
      */
     TreCollection parseTREs(NitfReader reader, int length, TreSource source) throws ParseException;
+
+    /**
+     * Handle the text segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException;
+
+    /**
+     * Handle the data extension segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException;
+
+    /**
+     * Handle the graphic segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException;
+
+    /**
+     * Handle the image segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException;
+
+    /**
+     * Handle the label segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException;
+
+    /**
+     * Handle the symbol segment header and data.
+     *
+     * @param reader the reader to use, assumed to be positioned at the start of the header
+     * @param dataLength the length of the data in this segment.
+     * @throws ParseException if there is a problem handling the segment
+     */
+    void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException;
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
@@ -150,4 +150,18 @@ public interface DataExtensionSegment extends CommonSegment {
      * @return data for this DES.
      */
     ImageInputStream getData();
+
+    /**
+     * Get the length of the data for this segment.
+     *
+     * @return the number of bytes of data for this segment.
+     */
+    long getDataLength();
+
+    /**
+     * Set the length of data for this segment.
+     *
+     * @param length the number of bytes of data in this segment.
+     */
+    void setDataLength(final long length);
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
@@ -14,10 +14,15 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
+import java.io.IOException;
+import java.text.ParseException;
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.common.CommonSegmentImpl;
 import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.CONTROLLED_EXTENSIONS;
+import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.DESITEM_LENGTH;
+import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.DESOFLW_LENGTH;
+import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.DESSHL_LENGTH;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.REGISTERED_EXTENSIONS;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.STREAMING_FILE_HEADER;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionConstants.TRE_OVERFLOW;
@@ -32,6 +37,7 @@ class DataExtensionSegmentImpl extends CommonSegmentImpl implements DataExtensio
     private int desItemOverflowed = 0;
     private String userDefinedSubheaderField = null;
     private ImageInputStream desData = null;
+    private long dataLength = 0;
 
     /**
         Default constructor.
@@ -202,5 +208,33 @@ class DataExtensionSegmentImpl extends CommonSegmentImpl implements DataExtensio
     @Override
     public ImageInputStream getData() {
         return desData;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getHeaderLength() throws ParseException, IOException {
+        long headerLength = DataExtensionConstants.DE.length()
+                + DataExtensionConstants.DESID_LENGTH
+                + DataExtensionConstants.DESVER_LENGTH
+                + getSecurityMetadata().getSerialisedLength();
+        if (isTreOverflowNitf20() || isTreOverflowNitf21()) {
+            headerLength += DESOFLW_LENGTH;
+            headerLength += DESITEM_LENGTH;
+        }
+        headerLength += DESSHL_LENGTH;
+        headerLength += getUserDefinedSubheaderField().length();
+        return headerLength;
+    }
+
+    @Override
+    public final long getDataLength() {
+        return dataLength;
+    }
+
+    @Override
+    public void setDataLength(final long length) {
+        dataLength = length;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentNitfParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentNitfParseStrategy.java
@@ -27,48 +27,48 @@ public class DataExtensionSegmentNitfParseStrategy extends SlottedNitfParseStrat
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, false));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, false));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, false));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        readGraphicSegment(reader, i, false);
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        readGraphicSegment(reader, false, dataLength);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, false));
+    public final void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, true));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, true, dataLength));
     }
 
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentParser.java
@@ -42,13 +42,15 @@ public class DataExtensionSegmentParser extends AbstractSegmentParser {
     /**
      * Parse DataExtensionSegment from the specified reader.
      *
-     * @param nitfReader - the NITF input reader.
-     * @return a fully parsed DataExtensionSegment.
+     * @param nitfReader the NITF input reader.
+     * @param dataLength the length of the data part of this segment
+     * @return a fully parsed DataExtensionSegment
      * @throws ParseException when the parser encounters unexpected input from the reader.
      */
-    public final DataExtensionSegment parse(final NitfReader nitfReader) throws ParseException {
+    public final DataExtensionSegment parse(final NitfReader nitfReader, final long dataLength) throws ParseException {
         reader = nitfReader;
         segment = new DataExtensionSegmentImpl();
+        segment.setDataLength(dataLength);
 
         readDE();
         readDESID();

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentWriter.java
@@ -55,7 +55,7 @@ public class DataExtensionSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthString(DE, DE.length());
         writeFixedLengthString(des.getIdentifier(), DESID_LENGTH);
         writeFixedLengthNumber(des.getDESVersion(), DESVER_LENGTH);
-        writeSecurityMetadata(des.getSecurityMetadata(), fileType);
+        writeSecurityMetadata(des.getSecurityMetadata());
         if (des.isTreOverflow(fileType)) {
             writeFixedLengthString(des.getOverflowedHeaderType(), DESOFLW_LENGTH);
             writeFixedLengthNumber(des.getItemOverflowed(), DESITEM_LENGTH);

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicDataExtractionParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicDataExtractionParseStrategy.java
@@ -25,48 +25,48 @@ class GraphicDataExtractionParseStrategy extends SlottedNitfParseStrategy {
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, false));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, false));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, false));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, i, true));
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, true, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, false));
+    public final void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, false));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, false, dataLength));
     }
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegment.java
@@ -202,4 +202,18 @@ public interface GraphicSegment extends CommonBasicSegment {
      */
     void setData(ImageInputStream data);
 
+    /**
+     * Get the length of the data for this segment.
+     *
+     * @return the number of bytes of data for this segment.
+     */
+    long getDataLength();
+
+    /**
+     * Set the length of data for this segment.
+     *
+     * @param length the number of bytes of data in this segment.
+     */
+    void setDataLength(final long length);
+
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentImpl.java
@@ -14,8 +14,13 @@
  */
 package org.codice.imaging.nitf.core.graphic;
 
+import java.io.IOException;
+import java.text.ParseException;
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
+import org.codice.imaging.nitf.core.common.CommonConstants;
+import org.codice.imaging.nitf.core.tre.TreParser;
+import org.codice.imaging.nitf.core.tre.TreSource;
 
 /**
     Graphic segment information (NITF 2.1 / NSIF 1.0 only).
@@ -33,6 +38,7 @@ class GraphicSegmentImpl extends CommonBasicSegmentImpl
     private int boundingBox2Row = 0;
     private int boundingBox2Column = 0;
     private ImageInputStream dataStream = null;
+    private long dataLength = 0;
 
     /**
         Default constructor.
@@ -308,5 +314,44 @@ class GraphicSegmentImpl extends CommonBasicSegmentImpl
     @Override
     public ImageInputStream getData() {
         return dataStream;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getHeaderLength() throws ParseException, IOException {
+        long headerLength = GraphicSegmentConstants.SY.length()
+                + GraphicSegmentConstants.SID_LENGTH
+                + GraphicSegmentConstants.SNAME_LENGTH
+                + getSecurityMetadata().getSerialisedLength()
+                + CommonConstants.ENCRYP_LENGTH
+                + GraphicSegmentConstants.SFMT_CGM.length()
+                + GraphicSegmentConstants.SSTRUCT.length()
+                + GraphicSegmentConstants.SDLVL_LENGTH
+                + GraphicSegmentConstants.SALVL_LENGTH
+                + GraphicSegmentConstants.SLOC_HALF_LENGTH * 2
+                + GraphicSegmentConstants.SBND1_HALF_LENGTH * 2
+                + GraphicSegmentConstants.SCOLOR_LENGTH
+                + GraphicSegmentConstants.SBND2_HALF_LENGTH * 2
+                + GraphicSegmentConstants.SRES.length()
+                + GraphicSegmentConstants.SXSHDL_LENGTH;
+        TreParser treParser = new TreParser();
+        int extendedDataLength = treParser.getTREs(this, TreSource.GraphicExtendedSubheaderData).length;
+        if (extendedDataLength > 0) {
+            headerLength += GraphicSegmentConstants.SXSOFL_LENGTH;
+            headerLength += extendedDataLength;
+        }
+        return headerLength;
+    }
+
+    @Override
+    public final long getDataLength() {
+        return dataLength;
+    }
+
+    @Override
+    public void setDataLength(final long length) {
+        dataLength = length;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentParser.java
@@ -56,15 +56,18 @@ public class GraphicSegmentParser extends AbstractSegmentParser {
      *
      * The reader provides the data. The parse strategy selects which data to store.
      *
-     * @param nitfReader - the NITF input reader.
-     * @param parseStrategy - the strategy that defines which elements to parse or skip.
+     * @param nitfReader the NITF input reader.
+     * @param parseStrategy the strategy that defines which elements to parse or skip.
+     * @param dataLength the length of the segment data part in bytes, excluding the header.
      * @return a fully parsed Graphic segment.
      * @throws ParseException when the parser encounters unexpected input from the reader.
      */
-    public final GraphicSegment parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy) throws ParseException {
+    public final GraphicSegment parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy,
+            final long dataLength) throws ParseException {
 
         reader = nitfReader;
         segment = new GraphicSegmentImpl();
+        segment.setDataLength(dataLength);
         parsingStrategy = parseStrategy;
 
         readSY();

--- a/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentWriter.java
@@ -18,7 +18,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
 import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
-import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SALVL_LENGTH;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SBND1_HALF_LENGTH;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SBND2_HALF_LENGTH;
@@ -63,7 +62,7 @@ public class GraphicSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthString(SY, SY.length());
         writeFixedLengthString(graphicSegment.getIdentifier(), SID_LENGTH);
         writeFixedLengthString(graphicSegment.getGraphicName(), SNAME_LENGTH);
-        writeSecurityMetadata(graphicSegment.getSecurityMetadata(), FileType.NITF_TWO_ONE);
+        writeSecurityMetadata(graphicSegment.getSecurityMetadata());
         writeENCRYP();
         writeFixedLengthString(SFMT_CGM, SFMT_CGM.length());
         writeFixedLengthString(SSTRUCT, SSTRUCT.length());

--- a/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeader.java
@@ -14,7 +14,6 @@
  */
 package org.codice.imaging.nitf.core.header;
 
-import java.util.List;
 import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
@@ -34,20 +33,6 @@ public interface NitfHeader extends TaggedRecordExtensionHandler {
     @return complexity level
      */
     int getComplexityLevel();
-
-    /**
-     * Return the DES data lengths.
-     *
-     * @return the list of data extension segment data lengths
-     */
-    List<Integer> getDataExtensionSegmentDataLengths();
-
-    /**
-     * Return the DES subheader lengths.
-     *
-     * @return the list of data extension segment subheader lengths
-     */
-    List<Integer> getDataExtensionSegmentSubHeaderLengths();
 
     /**
      *
@@ -103,52 +88,6 @@ public interface NitfHeader extends TaggedRecordExtensionHandler {
     FileType getFileType();
 
     /**
-     * Return the graphic (or symbol) segment data lengths.
-     *
-     * @return the list of graphic segment data lengths
-     */
-    List<Integer> getGraphicSegmentDataLengths();
-
-    /**
-     * Return the graphic (or symbol) segment subheader lengths.
-     *
-     * @return the list of graphic segment subheader lengths
-     */
-    List<Integer> getGraphicSegmentSubHeaderLengths();
-
-    /**
-     * Return the image segment data lengths.
-     *
-     * @return the list of image segment data lengths
-     */
-    List<Long> getImageSegmentDataLengths();
-
-    /**
-     * Return the image segment subheader lengths.
-     *
-     * @return the list of image segment subheader lengths
-     */
-    List<Integer> getImageSegmentSubHeaderLengths();
-
-    /**
-     * Return the label segment data lengths.
-     *
-     * This will always be an empty list for NITF 2.1 / NSIF 1.0 file, which do not have label segments.
-     *
-     * @return the list of label segment data lengths
-     */
-    List<Integer> getLabelSegmentDataLengths();
-
-    /**
-     * Return the label segment subheader lengths.
-     *
-     * This will always be an empty list for NITF 2.1 / NSIF 1.0 file, which do not have label segments.
-     *
-     * @return the list of label segment subheader lengths
-     */
-    List<Integer> getLabelSegmentSubHeaderLengths();
-
-    /**
      * Return the originating station identifier (OSTAID) for the file.
      *
      * "This field shall contain the identification code or name of the
@@ -190,34 +129,6 @@ public interface NitfHeader extends TaggedRecordExtensionHandler {
      * @return the standard type.
      */
     String getStandardType();
-
-    /**
-     * Return the symbol (or graphic) segment data lengths.
-     *
-     * @return the list of symbol segment data lengths
-     */
-    List<Integer> getSymbolSegmentDataLengths();
-
-    /**
-     * Return the symbol (or graphic) segment subheader lengths.
-     *
-     * @return the list of symbol segment subheader lengths
-     */
-    List<Integer> getSymbolSegmentSubHeaderLengths();
-
-    /**
-     * Return the text segment data lengths.
-     *
-     * @return the list of text segment data lengths
-     */
-    List<Integer> getTextSegmentDataLengths();
-
-    /**
-     * Return the text segment subheader lengths.
-     *
-     * @return the list of text segment subheader lengths
-     */
-    List<Integer> getTextSegmentSubHeaderLengths();
 
     /**
      * Return the user defined header overflow (UDHOFL) for the file.

--- a/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeaderImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeaderImpl.java
@@ -14,8 +14,6 @@
  */
 package org.codice.imaging.nitf.core.header;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
@@ -38,18 +36,6 @@ class NitfHeaderImpl extends TaggedRecordExtensionHandlerImpl implements NitfHea
     private String nitfOriginatorsPhoneNumber = null;
     private int nitfUserDefinedHeaderOverflow = 0;
     private int nitfExtendedHeaderDataOverflow = 0;
-
-    private final List<Integer> lish = new ArrayList<>();
-    private final List<Long> li = new ArrayList<>();
-    private final List<Integer> lssh = new ArrayList<>();
-    private final List<Integer> ls = new ArrayList<>();
-    private final List<Integer> llsh = new ArrayList<>();
-    private final List<Integer> ll = new ArrayList<>();
-    private final List<Integer> ltsh = new ArrayList<>();
-    private final List<Integer> lt = new ArrayList<>();
-    private final List<Integer> ldsh = new ArrayList<>();
-    private final List<Integer> ld = new ArrayList<>();
-
 
     /**
         Default constructor.
@@ -333,130 +319,6 @@ class NitfHeaderImpl extends TaggedRecordExtensionHandlerImpl implements NitfHea
     @Override
     public final int getUserDefinedHeaderOverflow() {
         return nitfUserDefinedHeaderOverflow;
-    }
-
-    /**
-     * Return the image segment subheader lengths.
-     *
-     * @return the list of image segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getImageSegmentSubHeaderLengths() {
-        return lish;
-    }
-
-    /**
-     * Return the image segment data lengths.
-     *
-     * @return the list of image segment data lengths
-     */
-    @Override
-    public final List<Long> getImageSegmentDataLengths() {
-        return li;
-    }
-
-    /**
-     * Return the graphic (or symbol) segment subheader lengths.
-     *
-     * @return the list of graphic segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getGraphicSegmentSubHeaderLengths() {
-        return lssh;
-    }
-
-    /**
-     * Return the graphic (or symbol) segment data lengths.
-     *
-     * @return the list of graphic segment data lengths
-     */
-    @Override
-    public final List<Integer> getGraphicSegmentDataLengths() {
-        return ls;
-    }
-
-    /**
-     * Return the symbol (or graphic) segment subheader lengths.
-     *
-     * @return the list of symbol segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getSymbolSegmentSubHeaderLengths() {
-        return lssh;
-    }
-
-    /**
-     * Return the symbol (or graphic) segment data lengths.
-     *
-     * @return the list of symbol segment data lengths
-     */
-    @Override
-    public final List<Integer> getSymbolSegmentDataLengths() {
-        return ls;
-    }
-
-    /**
-     * Return the label segment subheader lengths.
-     *
-     * This will always be an empty list for NITF 2.1 / NSIF 1.0 file, which do not have label segments.
-     *
-     * @return the list of label segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getLabelSegmentSubHeaderLengths() {
-        return llsh;
-    }
-
-    /**
-     * Return the label segment data lengths.
-     *
-     * This will always be an empty list for NITF 2.1 / NSIF 1.0 file, which do not have label segments.
-     *
-     * @return the list of label segment data lengths
-     */
-    @Override
-    public final List<Integer> getLabelSegmentDataLengths() {
-        return ll;
-    }
-
-    /**
-     * Return the text segment subheader lengths.
-     *
-     * @return the list of text segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getTextSegmentSubHeaderLengths() {
-        return ltsh;
-    }
-
-    /**
-     * Return the text segment data lengths.
-     *
-     * @return the list of text segment data lengths
-     */
-    @Override
-    public final List<Integer> getTextSegmentDataLengths() {
-        return lt;
-    }
-
-    /**
-     * Return the DES subheader lengths.
-     *
-     * @return the list of data extension segment subheader lengths
-     */
-    @Override
-    public final List<Integer> getDataExtensionSegmentSubHeaderLengths() {
-        return ldsh;
-    }
-
-    /**
-     * Return the DES data lengths.
-     *
-     * @return the list of data extension segment data lengths
-     */
-    @Override
-    public final List<Integer> getDataExtensionSegmentDataLengths() {
-        return ld;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageConstants.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageConstants.java
@@ -309,6 +309,7 @@ public final class ImageConstants {
      * See MIL-STD-2500C Table A-3.
      */
     public static final int NELUT_LENGTH = 5;
+    static final int MAX_NUM_BANDS_IN_NBANDS_FIELD = 9;
 
     private ImageConstants() {
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageDataExtractionParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageDataExtractionParseStrategy.java
@@ -15,7 +15,6 @@
 package org.codice.imaging.nitf.core.image;
 
 import java.text.ParseException;
-
 import org.codice.imaging.nitf.core.SlottedNitfParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfReader;
 
@@ -27,47 +26,47 @@ public class ImageDataExtractionParseStrategy extends SlottedNitfParseStrategy {
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, true));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, true, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, false));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, false));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, i, false));
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, false));
+    public final void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, false));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, false, dataLength));
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegment.java
@@ -583,4 +583,18 @@ public interface ImageSegment extends CommonBasicSegment {
      * @param data the data to set.
      */
     void setData(ImageInputStream data);
+
+    /**
+     * Get the length of the data for this segment.
+     *
+     * @return the number of bytes of data for this segment.
+     */
+    long getDataLength();
+
+    /**
+     * Set the length of data for this segment.
+     *
+     * @param length the number of bytes of data in this segment.
+     */
+    void setDataLength(final long length);
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentParser.java
@@ -15,8 +15,6 @@
 package org.codice.imaging.nitf.core.image;
 
 import java.text.ParseException;
-import java.util.EnumSet;
-import java.util.Set;
 import org.codice.imaging.nitf.core.common.AbstractSegmentParser;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfParseStrategy;
@@ -70,12 +68,6 @@ public class ImageSegmentParser extends AbstractSegmentParser {
     private int userDefinedImageDataLength = 0;
     private int imageExtendedSubheaderDataLength = 0;
 
-    private static final Set<ImageCompression> HAS_COMRAT = EnumSet.of(ImageCompression.BILEVEL, ImageCompression.JPEG,
-        ImageCompression.VECTORQUANTIZATION, ImageCompression.LOSSLESSJPEG, ImageCompression.JPEG2000, ImageCompression.DOWNSAMPLEDJPEG,
-        ImageCompression.BILEVELMASK, ImageCompression.JPEGMASK, ImageCompression.VECTORQUANTIZATIONMASK,
-        ImageCompression.LOSSLESSJPEGMASK, ImageCompression.JPEG2000MASK, ImageCompression.USERDEFINED, ImageCompression.USERDEFINEDMASK,
-        ImageCompression.ARIDPCM, ImageCompression.ARIDPCMMASK);
-
     private ImageSegmentImpl segment = null;
 
     /**
@@ -91,12 +83,15 @@ public class ImageSegmentParser extends AbstractSegmentParser {
      * protect against parallel runs.
      * @param nitfReader the reader to use to get the data
      * @param parseStrategy the parsing strategy to use to process the data
+     * @param dataLength the length of the data associated with this segment.
      * @return the parsed image segment
      * @throws ParseException on parse failure
      */
-    public final ImageSegmentImpl parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy) throws ParseException {
+    public final ImageSegmentImpl parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy,
+            final long dataLength) throws ParseException {
         reader = nitfReader;
         segment = new ImageSegmentImpl();
+        segment.setDataLength(dataLength);
         parsingStrategy = parseStrategy;
 
         readIM();
@@ -124,7 +119,7 @@ public class ImageSegmentParser extends AbstractSegmentParser {
             segment.addImageComment(reader.readTrimmedBytes(ICOM_LENGTH));
         }
         readIC();
-        if (hasCOMRAT()) {
+        if (segment.hasCOMRAT()) {
             readCOMRAT();
         }
         readNBANDS();
@@ -158,10 +153,6 @@ public class ImageSegmentParser extends AbstractSegmentParser {
             readIXSHD();
         }
         return segment;
-    }
-
-    private Boolean hasCOMRAT() {
-        return HAS_COMRAT.contains(segment.getImageCompression());
     }
 
     private void readIM() throws ParseException {

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
@@ -69,7 +69,6 @@ import org.codice.imaging.nitf.core.tre.TreSource;
 public class ImageSegmentWriter extends AbstractSegmentWriter {
 
     private static final int NUM_PARTS_IN_IGEOLO = 4;
-    private static final int MAX_NUM_BANDS_IN_NBANDS_FIELD = 9;
 
     /**
      * Constructor.
@@ -95,7 +94,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
         writeDateTime(imageSegment.getImageDateTime());
         writeFixedLengthString(imageSegment.getImageTargetId().toString(), TGTID_LENGTH);
         writeFixedLengthString(imageSegment.getImageIdentifier2(), IID2_LENGTH);
-        writeSecurityMetadata(imageSegment.getSecurityMetadata(), fileType);
+        writeSecurityMetadata(imageSegment.getSecurityMetadata());
         writeENCRYP();
         writeFixedLengthString(imageSegment.getImageSource(), ISORCE_LENGTH);
         writeFixedLengthNumber(imageSegment.getNumberOfRows(), NROWS_LENGTH);
@@ -126,7 +125,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
             writeFixedLengthString(imageSegment.getCompressionRate(), COMRAT_LENGTH);
         }
 
-        if (imageSegment.getNumBands() <= MAX_NUM_BANDS_IN_NBANDS_FIELD) {
+        if (imageSegment.getNumBands() <= ImageConstants.MAX_NUM_BANDS_IN_NBANDS_FIELD) {
             writeFixedLengthNumber(imageSegment.getNumBands(), NBANDS_LENGTH);
         } else {
             writeFixedLengthNumber(0, NBANDS_LENGTH);

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
@@ -14,8 +14,13 @@
  */
 package org.codice.imaging.nitf.core.label;
 
-import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
+import java.io.IOException;
+import java.text.ParseException;
 import org.codice.imaging.nitf.core.RGBColour;
+import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
+import org.codice.imaging.nitf.core.common.CommonConstants;
+import org.codice.imaging.nitf.core.tre.TreParser;
+import org.codice.imaging.nitf.core.tre.TreSource;
 
 /**
     Label segment information (NITF 2.0 only).
@@ -213,6 +218,33 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     @Override
     public void setData(final String labelData) {
         labelText = labelData;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final long getHeaderLength() throws ParseException, IOException {
+        long headerLength = LabelConstants.LA.length()
+                + LabelConstants.LID_LENGTH
+                + getSecurityMetadata().getSerialisedLength()
+                + CommonConstants.ENCRYP_LENGTH
+                + LabelConstants.LFS_LENGTH
+                + LabelConstants.LCW_LENGTH
+                + LabelConstants.LCH_LENGTH
+                + LabelConstants.LDLVL_LENGTH
+                + LabelConstants.LALVL_LENGTH
+                + LabelConstants.LLOC_HALF_LENGTH * 2
+                + RGBColour.RGB_COLOUR_LENGTH
+                + RGBColour.RGB_COLOUR_LENGTH
+                + LabelConstants.LXSHDL_LENGTH;
+        TreParser treParser = new TreParser();
+        int extendedDataLength = treParser.getTREs(this, TreSource.LabelExtendedSubheaderData).length;
+        if (extendedDataLength > 0) {
+            headerLength += LabelConstants.LXSOFL_LENGTH;
+            headerLength += extendedDataLength;
+        }
+        return headerLength;
     }
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentWriter.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.text.ParseException;
 import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
-import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.label.LabelConstants.LA;
 import static org.codice.imaging.nitf.core.label.LabelConstants.LALVL_LENGTH;
 import static org.codice.imaging.nitf.core.label.LabelConstants.LCH_LENGTH;
@@ -58,7 +57,7 @@ public class LabelSegmentWriter extends AbstractSegmentWriter {
     public final void writeLabel(final LabelSegment labelSegment) throws IOException, ParseException {
         writeFixedLengthString(LA, LA.length());
         writeFixedLengthString(labelSegment.getIdentifier(), LID_LENGTH);
-        writeSecurityMetadata(labelSegment.getSecurityMetadata(), FileType.NITF_TWO_ZERO);
+        writeSecurityMetadata(labelSegment.getSecurityMetadata());
         writeENCRYP();
         writeFixedLengthString(" ", LFS_LENGTH);
         writeFixedLengthNumber(labelSegment.getLabelCellWidth(), LCW_LENGTH);

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadataImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/FileSecurityMetadataImpl.java
@@ -69,5 +69,16 @@ class FileSecurityMetadataImpl extends SecurityMetadataImpl implements FileSecur
     public final String getFileNumberOfCopies() {
         return nitfFileNumberOfCopies;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long getSerialisedLength() {
+        long len = super.getSerialisedLength();
+        len += FileSecurityConstants.FSCOP_LENGTH;
+        len += FileSecurityConstants.FSCPYS_LENGTH;
+        return len;
+    }
 };
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadata.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadata.java
@@ -14,10 +14,19 @@
  */
 package org.codice.imaging.nitf.core.security;
 
+import org.codice.imaging.nitf.core.common.FileType;
+
 /**
- Security metadata for a NITF file header or segment subheader.
+ * Security metadata for a NITF file header or segment subheader.
  */
 public interface SecurityMetadata {
+
+    /**
+     * Get the file type (NITF version) for this metadata.
+     *
+     * @return FileType for this metadata.
+     */
+    FileType getFileType();
 
     /**
      Return the security classification.
@@ -298,4 +307,11 @@ public interface SecurityMetadata {
      * @return true if this file has the special-case downgrade date field.
      */
     boolean hasDowngradeMagicValue();
+
+    /**
+     * Get the length of the metadata.
+     *
+     * @return the length of the serialised metadata, in bytes
+     */
+    long getSerialisedLength();
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataFactory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataFactory.java
@@ -15,29 +15,6 @@
 package org.codice.imaging.nitf.core.security;
 
 import org.codice.imaging.nitf.core.common.FileType;
-import static org.codice.imaging.nitf.core.security.FileSecurityConstants.FSCOP_LENGTH;
-import static org.codice.imaging.nitf.core.security.FileSecurityConstants.FSCPYS_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCATP_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCAUT20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCAUT_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCLSY_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCLTX_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCODE20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCODE_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCRSN_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCTLH20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCTLH_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCTLN20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSCTLN_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDCDT_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDCTP_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDCXM_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDGDT_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDG_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDWNG20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSREL20_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSREL_LENGTH;
-import static org.codice.imaging.nitf.core.security.SecurityConstants.XSSRDT_LENGTH;
 
 /**
  * Factory for SecurityMetadata and FileSecurityMetadata instances.
@@ -60,8 +37,8 @@ public final class SecurityMetadataFactory {
     public static FileSecurityMetadata getDefaultFileSecurityMetadata(final FileType fileType) {
         FileSecurityMetadataImpl defaultMetadata = new FileSecurityMetadataImpl();
         fillDefaultMetadata(defaultMetadata, fileType);
-        defaultMetadata.setFileCopyNumber(spaceFillForLength(FSCOP_LENGTH));
-        defaultMetadata.setFileNumberOfCopies(spaceFillForLength(FSCPYS_LENGTH));
+        defaultMetadata.setFileCopyNumber("");
+        defaultMetadata.setFileNumberOfCopies("");
         return defaultMetadata;
     }
 
@@ -83,41 +60,33 @@ public final class SecurityMetadataFactory {
     }
 
     private static void fillDefaultMetadata(final SecurityMetadataImpl meta, final FileType fileType) {
+        meta.setFileType(fileType);
         meta.setSecurityClassification(SecurityClassification.UNCLASSIFIED);
-        meta.setSecurityClassificationSystem(spaceFillForLength(XSCLSY_LENGTH));
+        meta.setSecurityClassificationSystem("");
         if (fileType.equals(FileType.NITF_TWO_ONE) || fileType.equals(FileType.NSIF_ONE_ZERO)) {
-            meta.setCodewords(spaceFillForLength(XSCODE_LENGTH));
-            meta.setControlAndHandling(spaceFillForLength(XSCTLH_LENGTH));
-            meta.setReleaseInstructions(spaceFillForLength(XSREL_LENGTH));
-            meta.setDeclassificationType(spaceFillForLength(XSDCTP_LENGTH));
-            meta.setDeclassificationDate(spaceFillForLength(XSDCDT_LENGTH));
-            meta.setDeclassificationExemption(spaceFillForLength(XSDCXM_LENGTH));
-            meta.setDowngrade(spaceFillForLength(XSDG_LENGTH));
-            meta.setDowngradeDate(spaceFillForLength(XSDGDT_LENGTH));
-            meta.setClassificationText(spaceFillForLength(XSCLTX_LENGTH));
-            meta.setClassificationAuthorityType(spaceFillForLength(XSCATP_LENGTH));
-            meta.setClassificationAuthority(spaceFillForLength(XSCAUT_LENGTH));
-            meta.setClassificationReason(spaceFillForLength(XSCRSN_LENGTH));
-            meta.setSecuritySourceDate(spaceFillForLength(XSSRDT_LENGTH));
-            meta.setSecurityControlNumber(spaceFillForLength(XSCTLN_LENGTH));
+            meta.setCodewords("");
+            meta.setControlAndHandling("");
+            meta.setReleaseInstructions("");
+            meta.setDeclassificationType("");
+            meta.setDeclassificationDate("");
+            meta.setDeclassificationExemption("");
+            meta.setDowngrade("");
+            meta.setDowngradeDate("");
+            meta.setClassificationText("");
+            meta.setClassificationAuthorityType("");
+            meta.setClassificationAuthority("");
+            meta.setClassificationReason("");
+            meta.setSecuritySourceDate("");
+            meta.setSecurityControlNumber("");
         } else if (fileType.equals(FileType.NITF_TWO_ZERO)) {
-            meta.setCodewords(spaceFillForLength(XSCODE20_LENGTH));
-            meta.setControlAndHandling(spaceFillForLength(XSCTLH20_LENGTH));
-            meta.setReleaseInstructions(spaceFillForLength(XSREL20_LENGTH));
-            meta.setClassificationAuthority(spaceFillForLength(XSCAUT20_LENGTH));
-            meta.setSecurityControlNumber(spaceFillForLength(XSCTLN20_LENGTH));
-            meta.setDowngradeDateOrSpecialCase(spaceFillForLength(XSDWNG20_LENGTH));
+            meta.setSecurityClassificationSystem(null);
+            meta.setCodewords("");
+            meta.setControlAndHandling("");
+            meta.setReleaseInstructions("");
+            meta.setClassificationAuthority("");
+            meta.setSecurityControlNumber("");
+            meta.setDowngradeDateOrSpecialCase("");
             // Do not need Security Downgrade here - its conditional on the previous field being "999998"
         }
-    }
-
-    /**
-     * Create an empty (space-filled) string of specified length.
-     *
-     * @param length the length of the string to create
-     * @return the space-filled string
-     */
-    private static String spaceFillForLength(final int length) {
-        return String.format("%1$-" + length + "s", "");
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataImpl.java
@@ -14,12 +14,16 @@
  */
 package org.codice.imaging.nitf.core.security;
 
+import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.security.SecurityConstants.DOWNGRADE_EVENT_MAGIC;
+import static org.codice.imaging.nitf.core.security.SecurityConstants.XSDEVT20_LENGTH;
 
 /**
  * Security metadata for a NITF file header or segment subheader.
  */
 class SecurityMetadataImpl implements SecurityMetadata {
+
+    private FileType nitfFileType = FileType.NITF_TWO_ONE;
 
     private SecurityClassification securityClassification = SecurityClassification.UNKNOWN;
     private String nitfSecurityClassificationSystem = null;
@@ -52,11 +56,20 @@ class SecurityMetadataImpl implements SecurityMetadata {
     SecurityMetadataImpl() {
     }
 
-    /**
-        Set the security classification.
+    public void setFileType(final FileType fileType) {
+        nitfFileType = fileType;
+    }
 
-        @param classification security classification
-    */
+    @Override
+    public final FileType getFileType() {
+        return nitfFileType;
+    }
+
+    /**
+     * Set the security classification.
+     *
+     * @param classification security classification
+     */
     public final void setSecurityClassification(final SecurityClassification classification) {
         this.securityClassification = classification;
     }
@@ -520,5 +533,29 @@ class SecurityMetadataImpl implements SecurityMetadata {
     @Override
     public boolean hasDowngradeMagicValue() {
         return (DOWNGRADE_EVENT_MAGIC.equals(getDowngradeDateOrSpecialCase()));
+    }
+
+    @Override
+    public long getSerialisedLength() {
+        long len = SecurityConstants.XSCLAS_LENGTH + SecurityConstants.XSCLSY_LENGTH + SecurityConstants.XSCODE_LENGTH
+                + SecurityConstants.XSCTLH_LENGTH + SecurityConstants.XSREL_LENGTH + SecurityConstants.XSDCTP_LENGTH
+                + SecurityConstants.XSDCDT_LENGTH + SecurityConstants.XSDCXM_LENGTH + SecurityConstants.XSDG_LENGTH
+                + SecurityConstants.XSDGDT_LENGTH + SecurityConstants.XSCLTX_LENGTH + SecurityConstants.XSCATP_LENGTH
+                + SecurityConstants.XSCAUT_LENGTH + SecurityConstants.XSCRSN_LENGTH + SecurityConstants.XSSRDT_LENGTH
+                + SecurityConstants.XSCTLN_LENGTH;
+        len += calculateExtraHeaderLength();
+        return len;
+    }
+
+    /**
+     * Calculate the extra header length that can occur in NITF 2.0 files for downgrades.
+     *
+     * @return the number of additional bytes that will be required for special downgrade text.
+     */
+    private int calculateExtraHeaderLength() {
+        if ((getFileType().equals(FileType.NITF_TWO_ZERO)) && hasDowngradeMagicValue()) {
+            return XSDEVT20_LENGTH;
+        }
+        return 0;
     }
 };

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataParser.java
@@ -88,6 +88,7 @@ public class SecurityMetadataParser {
     protected final void doParse(final NitfReader nitfReader, final SecurityMetadataImpl securityMetadata) throws ParseException {
         reader = nitfReader;
         metadata = securityMetadata;
+        securityMetadata.setFileType(nitfReader.getFileType());
 
         switch (nitfReader.getFileType()) {
             case NITF_TWO_ZERO:

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/SecurityMetadataWriter.java
@@ -64,11 +64,10 @@ public class SecurityMetadataWriter extends AbstractSegmentWriter {
      * Write out normal segment-level security metadata.
      *
      * @param securityMetadata the metadata to write
-     * @param fileType the type of file (NITF version) to write out.
      * @throws IOException on write failure.
      */
-    public final void writeMetadata(final SecurityMetadata securityMetadata, final FileType fileType) throws IOException {
-        if (fileType == FileType.NITF_TWO_ZERO) {
+    public final void writeMetadata(final SecurityMetadata securityMetadata) throws IOException {
+        if (securityMetadata.getFileType() == FileType.NITF_TWO_ZERO) {
             writeSecurityMetadata20(securityMetadata);
         } else {
             writeSecurityMetadata21(securityMetadata);
@@ -111,26 +110,11 @@ public class SecurityMetadataWriter extends AbstractSegmentWriter {
      * Write file-header level security metadata.
      *
      * @param fsmeta the file-level security metadata to write out
-     * @param fileType the type of file (NITF version) that the security is for.
      * @throws IOException on write failure.
      */
-    public final void writeFileSecurityMetadata(final FileSecurityMetadata fsmeta, final FileType fileType) throws IOException {
-        writeSecurityMetadata(fsmeta, fileType);
+    public final void writeFileSecurityMetadata(final FileSecurityMetadata fsmeta) throws IOException {
+        writeSecurityMetadata(fsmeta);
         writeFixedLengthString(fsmeta.getFileCopyNumber(), FSCOP_LENGTH);
         writeFixedLengthString(fsmeta.getFileNumberOfCopies(), FSCPYS_LENGTH);
-    }
-
-    /**
-     * Calculate the extra header length that can occur in NITF 2.0 files for downgrades.
-     *
-     * @param securityMetadata the security metadata to check.
-     * @param fileType the type (NITF version) of file to verify.
-     * @return the number of additional bytes that will be required for special downgrade text.
-     */
-    public final int calculateExtraHeaderLength(final SecurityMetadata securityMetadata, final FileType fileType) {
-        if ((fileType.equals(FileType.NITF_TWO_ZERO)) && (securityMetadata.hasDowngradeMagicValue())) {
-            return XSDEVT20_LENGTH;
-        }
-        return 0;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegment.java
@@ -235,4 +235,18 @@ public interface SymbolSegment extends CommonBasicSegment {
      * @param data stream containing data for segment
      */
     void setData(ImageInputStream data);
+
+    /**
+     * Get the length of the data for this segment.
+     *
+     * @return the number of bytes of data for this segment.
+     */
+    long getDataLength();
+
+    /**
+     * Set the length of data for this segment.
+     *
+     * @param length the number of bytes of data in this segment.
+     */
+    void setDataLength(final long length);
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentParser.java
@@ -56,13 +56,16 @@ public class SymbolSegmentParser extends AbstractSegmentParser {
      *
      * @param nitfReader The NitfReader to read the SymbolSegment from.
      * @param parseStrategy the parsing strategy to use to process the data.
+     * @param dataLength the length of the segment data part in bytes, excluding the header
      * @return the parsed SymbolSegment.
      * @throws ParseException when the input from the NitfReader isn't what was expected.
      */
-    public final SymbolSegment parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy) throws ParseException {
+    public final SymbolSegment parse(final NitfReader nitfReader, final NitfParseStrategy parseStrategy,
+            final long dataLength) throws ParseException {
 
         reader = nitfReader;
         segment = new SymbolSegmentImpl();
+        segment.setDataLength(dataLength);
         parsingStrategy = parseStrategy;
 
         readSY();

--- a/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/symbol/SymbolSegmentWriter.java
@@ -18,7 +18,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.text.ParseException;
 import org.codice.imaging.nitf.core.common.AbstractSegmentWriter;
-import org.codice.imaging.nitf.core.common.FileType;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SALVL_LENGTH;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SCOLOR_LENGTH;
 import static org.codice.imaging.nitf.core.graphic.GraphicSegmentConstants.SDLVL_LENGTH;
@@ -65,7 +64,7 @@ public class SymbolSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthString(SY, SY.length());
         writeFixedLengthString(header.getIdentifier(), SID_LENGTH);
         writeFixedLengthString(header.getSymbolName(), SNAME_LENGTH);
-        writeSecurityMetadata(header.getSecurityMetadata(), FileType.NITF_TWO_ZERO);
+        writeSecurityMetadata(header.getSecurityMetadata());
         writeENCRYP();
         writeFixedLengthString(header.getSymbolType().getTextEquivalent(), SYTYPE_LENGTH);
         writeFixedLengthNumber(header.getNumberOfLinesPerSymbol(), NLIPS_LENGTH);

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextDataExtractionParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextDataExtractionParseStrategy.java
@@ -27,48 +27,48 @@ public class TextDataExtractionParseStrategy extends SlottedNitfParseStrategy {
      * {@inheritDoc}
      */
     @Override
-    protected final void handleImageSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getImageSegments().add(readImageSegment(reader, i, false));
+    public final void handleImageSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getImageSegments().add(readImageSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleSymbolSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, i, false));
+    public final void handleSymbolSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getSymbolSegments().add(readSymbolSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleLabelSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getLabelSegments().add(readLabelSegment(reader, i, false));
+    public final void handleLabelSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getLabelSegments().add(readLabelSegment(reader, dataLength, false));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleGraphicSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, i, false));
+    public final void handleGraphicSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getGraphicSegments().add(readGraphicSegment(reader, false, dataLength));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleTextSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getTextSegments().add(readTextSegment(reader, i, true));
+    public final void handleTextSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getTextSegments().add(readTextSegment(reader, dataLength, true));
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    protected final void handleDataExtensionSegment(final NitfReader reader, final int i) throws ParseException {
-        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, i, false));
+    public final void handleDataExtensionSegment(final NitfReader reader, final long dataLength) throws ParseException {
+        nitfStorage.getDataExtensionSegments().add(readDataExtensionSegment(reader, false, dataLength));
     }
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentFactory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.text;
+
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.common.NitfDateTime;
+import org.codice.imaging.nitf.core.security.SecurityMetadataFactory;
+
+/**
+ * Factory class for creating new TextSegment instances.
+ */
+public final class TextSegmentFactory {
+
+    private TextSegmentFactory() {
+    }
+
+    /**
+     * Create a default NITF text segment, without data.
+     *
+     * Note that this will not set an identifier - it will be empty (space filled on write). That may or may not be
+     * valid - it is application dependent.
+     *
+     * @param fileType the type (version) of NITF file this text segment is for
+     * @return default valid text segment, containing no text data.
+     */
+    public static TextSegment getDefault(final FileType fileType) {
+        TextSegment textSegment = new TextSegmentImpl();
+        textSegment.setIdentifier("");
+        textSegment.setAttachmentLevel(0);
+        textSegment.setTextDateTime(NitfDateTime.getNitfDateTimeForNow());
+        textSegment.setTextTitle("");
+        textSegment.setSecurityMetadata(SecurityMetadataFactory.getDefaultMetadata(fileType));
+        textSegment.setTextFormat(TextFormat.UTF8SUBSET);
+        return textSegment;
+    }
+
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentImpl.java
@@ -14,8 +14,14 @@
  */
 package org.codice.imaging.nitf.core.text;
 
+import java.io.IOException;
+import java.text.ParseException;
 import org.codice.imaging.nitf.core.common.CommonBasicSegmentImpl;
+import org.codice.imaging.nitf.core.common.CommonConstants;
+import static org.codice.imaging.nitf.core.common.CommonConstants.STANDARD_DATE_TIME_LENGTH;
 import org.codice.imaging.nitf.core.common.NitfDateTime;
+import org.codice.imaging.nitf.core.tre.TreParser;
+import org.codice.imaging.nitf.core.tre.TreSource;
 
 /**
  * Text segment information.
@@ -40,6 +46,7 @@ class TextSegmentImpl extends CommonBasicSegmentImpl implements TextSegment {
      *
      * @param dateTime the date and time of the text.
      */
+    @Override
     public final void setTextDateTime(final NitfDateTime dateTime) {
         textDateTime = dateTime;
     }
@@ -98,5 +105,28 @@ class TextSegmentImpl extends CommonBasicSegmentImpl implements TextSegment {
     @Override
     public final void setData(final String text) {
         textData = text;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final long getHeaderLength() throws ParseException, IOException {
+        long headerLength = TextConstants.TE.length()
+                + TextConstants.TEXTID_LENGTH
+                + TextConstants.TXTALVL_LENGTH
+                + STANDARD_DATE_TIME_LENGTH
+                + TextConstants.TXTITL_LENGTH
+                + getSecurityMetadata().getSerialisedLength()
+                + CommonConstants.ENCRYP_LENGTH
+                + TextConstants.TXTFMT_LENGTH
+                + TextConstants.TXSHDL_LENGTH;
+        TreParser treParser = new TreParser();
+        int extendedDataLength = treParser.getTREs(this, TreSource.TextExtendedSubheaderData).length;
+        if (extendedDataLength > 0) {
+            headerLength += TextConstants.TXSOFL_LENGTH;
+            headerLength += extendedDataLength;
+        }
+        return headerLength;
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/text/TextSegmentWriter.java
@@ -62,7 +62,7 @@ public class TextSegmentWriter extends AbstractSegmentWriter {
         }
         writeDateTime(textSegment.getTextDateTime());
         writeFixedLengthString(textSegment.getTextTitle(), TXTITL_LENGTH);
-        writeSecurityMetadata(textSegment.getSecurityMetadata(), fileType);
+        writeSecurityMetadata(textSegment.getSecurityMetadata());
         writeENCRYP();
         writeFixedLengthString(textSegment.getTextFormat().getTextEquivalent(), TXTFMT_LENGTH);
         byte[] textExtendedSubheaderData = mTreParser.getTREs(textSegment, TreSource.TextExtendedSubheaderData);

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.time.format.DateTimeFormatter;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf20SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileReader;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
@@ -37,7 +38,6 @@ import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
 import org.codice.imaging.nitf.core.label.LabelSegment;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
-import org.codice.imaging.nitf.core.security.SecurityClassification;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.symbol.SymbolColour;
 import org.codice.imaging.nitf.core.symbol.SymbolSegment;
@@ -47,7 +47,6 @@ import org.codice.imaging.nitf.core.text.TextFormat;
 import org.codice.imaging.nitf.core.text.TextSegment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -97,7 +96,7 @@ public class Nitf20HeaderTest {
         assertEquals("1994-04-03 19:16:36", formatter.format(header.getFileDateTime().getZonedDateTime()));
         assertEquals("checks the handling of an NITF file w/ only a text file.", header.getFileTitle());
         FileSecurityMetadata securityMetadata = header.getFileSecurityMetadata();
-        assertUnclasAndEmpty(securityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(securityMetadata);
         assertEquals("999998", securityMetadata.getDowngradeDateOrSpecialCase());
         assertEquals("This  file   will not need a downgrade.", securityMetadata.getDowngradeEvent());
 
@@ -117,7 +116,7 @@ public class Nitf20HeaderTest {
         assertEquals("1993-03-27 23:55:36", formatter.format(textSegment.getTextDateTime().getZonedDateTime()));
         assertEquals("This is the title of unclassified text file #1 in NITF  file   U21H00N1.", textSegment.getTextTitle());
         SecurityMetadata textSecurityMetadata = textSegment.getSecurityMetadata();
-        assertUnclasAndEmpty(textSecurityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(textSecurityMetadata);
         assertEquals("", textSecurityMetadata.getSecurityControlNumber());
         assertEquals("999998", textSecurityMetadata.getDowngradeDateOrSpecialCase());
         assertEquals("This text will never need downgrading.", textSecurityMetadata.getDowngradeEvent());
@@ -142,7 +141,7 @@ public class Nitf20HeaderTest {
         assertEquals("1992-11-03 13:52:26", formatter.format(nitfHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("This NITF message contains 5 images, 4 symbols, 4 labels and 1 text.", nitfHeader.getFileTitle());
         FileSecurityMetadata securityMetadata = nitfHeader.getFileSecurityMetadata();
-        assertUnclasAndEmpty(securityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(securityMetadata);
         assertEquals("999998", securityMetadata.getDowngradeDateOrSpecialCase());
         assertEquals("This message will not need a downgrade.", securityMetadata.getDowngradeEvent());
 
@@ -166,7 +165,7 @@ public class Nitf20HeaderTest {
         assertEquals("          ", imageSegment1.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment1.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment1.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment1.getSecurityMetadata());
         assertEquals("Unknown", imageSegment1.getImageSource());
         assertEquals(1024L, imageSegment1.getNumberOfRows());
         assertEquals(1024L, imageSegment1.getNumberOfColumns());
@@ -206,7 +205,7 @@ public class Nitf20HeaderTest {
         assertEquals("          ", imageSegment2.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment2.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment2.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment2.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment2.getSecurityMetadata());
         assertEquals("123456789012345678901234567890123456789012", imageSegment2.getImageSource());
         assertEquals(64L, imageSegment2.getNumberOfRows());
         assertEquals(64L, imageSegment2.getNumberOfColumns());
@@ -245,7 +244,7 @@ public class Nitf20HeaderTest {
         assertEquals("          ", imageSegment3.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment3.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment3.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment3.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment3.getSecurityMetadata());
         assertEquals("", imageSegment3.getImageSource());
         assertEquals(64L, imageSegment3.getNumberOfRows());
         assertEquals(64L, imageSegment3.getNumberOfColumns());
@@ -293,7 +292,7 @@ public class Nitf20HeaderTest {
         assertEquals("          ", imageSegment4.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment4.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment4.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment4.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment4.getSecurityMetadata());
         assertEquals("", imageSegment4.getImageSource());
         assertEquals(191L, imageSegment4.getNumberOfRows());
         assertEquals(231L, imageSegment4.getNumberOfColumns());
@@ -332,7 +331,7 @@ public class Nitf20HeaderTest {
         assertEquals("          ", imageSegment5.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment5.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment5.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment5.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment5.getSecurityMetadata());
         assertEquals("", imageSegment5.getImageSource());
         assertEquals(73L, imageSegment5.getNumberOfRows());
         assertEquals(181L, imageSegment5.getNumberOfColumns());
@@ -369,7 +368,7 @@ public class Nitf20HeaderTest {
         assertNotNull(symbolSegment1);
         assertEquals("0000000001", symbolSegment1.getIdentifier());
         assertEquals("Unclassified Symbol.", symbolSegment1.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
         assertEquals("999998", symbolSegment1.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This symbol will never need downgrading.", symbolSegment1.getSecurityMetadata().getDowngradeEvent());
         assertEquals(SymbolType.BITMAP, symbolSegment1.getSymbolType());
@@ -394,7 +393,7 @@ public class Nitf20HeaderTest {
         assertNotNull(symbolSegment2);
         assertEquals("0000000002", symbolSegment2.getIdentifier());
         assertEquals("Unclassified Symbol.", symbolSegment2.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment2.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment2.getSecurityMetadata());
         assertEquals("999998", symbolSegment2.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This symbol will never need downgrading.", symbolSegment2.getSecurityMetadata().getDowngradeEvent());
         assertEquals(SymbolType.BITMAP, symbolSegment2.getSymbolType());
@@ -419,7 +418,7 @@ public class Nitf20HeaderTest {
         assertNotNull(symbolSegment3);
         assertEquals("0000000003", symbolSegment3.getIdentifier());
         assertEquals("Unclassified Symbol.", symbolSegment3.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment3.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment3.getSecurityMetadata());
         assertEquals("999998", symbolSegment3.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This symbol will never need downgrading.", symbolSegment3.getSecurityMetadata().getDowngradeEvent());
         assertEquals(SymbolType.BITMAP, symbolSegment3.getSymbolType());
@@ -444,7 +443,7 @@ public class Nitf20HeaderTest {
         assertNotNull(symbolSegment4);
         assertEquals("0000000004", symbolSegment4.getIdentifier());
         assertEquals("Unclassified Symbol.", symbolSegment4.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment4.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment4.getSecurityMetadata());
         assertEquals("999998", symbolSegment4.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This symbol will never need downgrading.", symbolSegment4.getSecurityMetadata().getDowngradeEvent());
         assertEquals(SymbolType.BITMAP, symbolSegment4.getSymbolType());
@@ -468,7 +467,7 @@ public class Nitf20HeaderTest {
         LabelSegment labelSegment1 = parseStrategy.getNitfDataSource().getLabelSegments().get(0);
         assertNotNull(labelSegment1);
         assertEquals("0000000001", labelSegment1.getIdentifier());
-        assertUnclasAndEmpty(labelSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(labelSegment1.getSecurityMetadata());
         assertEquals("999998", labelSegment1.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This label will never need downgrading.", labelSegment1.getSecurityMetadata().getDowngradeEvent());
         assertEquals(20, labelSegment1.getLabelLocationRow());
@@ -489,7 +488,7 @@ public class Nitf20HeaderTest {
         LabelSegment labelSegment2 = parseStrategy.getNitfDataSource().getLabelSegments().get(1);
         assertNotNull(labelSegment2);
         assertEquals("0000000002", labelSegment2.getIdentifier());
-        assertUnclasAndEmpty(labelSegment2.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(labelSegment2.getSecurityMetadata());
         assertEquals("999998", labelSegment2.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This label will never need downgrading.", labelSegment2.getSecurityMetadata().getDowngradeEvent());
         assertEquals(100, labelSegment2.getLabelLocationRow());
@@ -510,7 +509,7 @@ public class Nitf20HeaderTest {
         LabelSegment labelSegment3 = parseStrategy.getNitfDataSource().getLabelSegments().get(2);
         assertNotNull(labelSegment3);
         assertEquals("0000000003", labelSegment3.getIdentifier());
-        assertUnclasAndEmpty(labelSegment3.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(labelSegment3.getSecurityMetadata());
         assertEquals("999998", labelSegment3.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This label will never need downgrading.", labelSegment3.getSecurityMetadata().getDowngradeEvent());
         assertEquals(-20, labelSegment3.getLabelLocationRow());
@@ -531,7 +530,7 @@ public class Nitf20HeaderTest {
         LabelSegment labelSegment4 = parseStrategy.getNitfDataSource().getLabelSegments().get(3);
         assertNotNull(labelSegment4);
         assertEquals("0000000004", labelSegment4.getIdentifier());
-        assertUnclasAndEmpty(labelSegment4.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(labelSegment4.getSecurityMetadata());
         assertEquals("999998", labelSegment4.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This label will never need downgrading.", labelSegment4.getSecurityMetadata().getDowngradeEvent());
         assertEquals(0, labelSegment4.getLabelLocationRow());
@@ -556,7 +555,7 @@ public class Nitf20HeaderTest {
         assertEquals("1990-06-07 21:11:36", formatter.format(textSegment.getTextDateTime().getZonedDateTime()));
         assertEquals("This is the title of unclassified text file #1 in NITF message JR1_B.", textSegment.getTextTitle());
         SecurityMetadata textSecurityMetadata = textSegment.getSecurityMetadata();
-        assertUnclasAndEmpty(textSecurityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(textSecurityMetadata);
         assertEquals("999998", textSecurityMetadata.getDowngradeDateOrSpecialCase());
         assertEquals("This text will never need downgrading.", textSecurityMetadata.getDowngradeEvent());
         assertEquals(TextFormat.BASICCHARACTERSET, textSegment.getTextFormat());
@@ -565,22 +564,4 @@ public class Nitf20HeaderTest {
         is.close();
     }
 
-    void assertUnclasAndEmpty(SecurityMetadata securityMetadata) {
-        assertNotNull(securityMetadata);
-        assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
-        assertNull(securityMetadata.getSecurityClassificationSystem());
-        assertEquals("", securityMetadata.getCodewords());
-        assertEquals("", securityMetadata.getControlAndHandling());
-        assertEquals("", securityMetadata.getReleaseInstructions());
-        assertNull(securityMetadata.getDeclassificationType());
-        assertNull(securityMetadata.getDeclassificationDate());
-        assertNull(securityMetadata.getDeclassificationExemption());
-        assertNull(securityMetadata.getDowngrade());
-        assertNull(securityMetadata.getDowngradeDate());
-        assertNull(securityMetadata.getClassificationText());
-        assertNull(securityMetadata.getClassificationAuthorityType());
-        assertEquals("", securityMetadata.getClassificationAuthority());
-        assertNull(securityMetadata.getClassificationReason());
-        assertEquals("", securityMetadata.getSecurityControlNumber());
-    }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20OverflowTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.time.format.DateTimeFormatter;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf20SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
@@ -37,7 +38,6 @@ import org.codice.imaging.nitf.core.image.PixelValueType;
 import org.codice.imaging.nitf.core.label.LabelSegment;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityClassification;
-import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.symbol.SymbolColour;
 import org.codice.imaging.nitf.core.symbol.SymbolSegment;
 import org.codice.imaging.nitf.core.symbol.SymbolType;
@@ -76,7 +76,7 @@ public class Nitf20OverflowTest {
         assertEquals("1997-09-15 09:00:00", formatter.format(nitfHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Checks overflow from all possible areas. Created by George Levy.", nitfHeader.getFileTitle());
         FileSecurityMetadata securityMetadata = nitfHeader.getFileSecurityMetadata();
-        assertUnclasAndEmpty(securityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(securityMetadata);
         assertEquals("      ", securityMetadata.getDowngradeDateOrSpecialCase());
         assertNull(securityMetadata.getDowngradeEvent());
 
@@ -101,7 +101,7 @@ public class Nitf20OverflowTest {
         assertEquals("          ", imageSegment1.getImageTargetId().getBasicEncyclopediaNumber());
         assertEquals("     ", imageSegment1.getImageTargetId().getOSuffix());
         assertEquals("  ", imageSegment1.getImageTargetId().getCountryCode());
-        assertUnclasAndEmpty(imageSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(imageSegment1.getSecurityMetadata());
         assertEquals("Unknown", imageSegment1.getImageSource());
         assertEquals(512L, imageSegment1.getNumberOfRows());
         assertEquals(512L, imageSegment1.getNumberOfColumns());
@@ -139,7 +139,7 @@ public class Nitf20OverflowTest {
         assertNotNull(symbolSegment1);
         assertEquals("Text", symbolSegment1.getIdentifier());
         assertEquals("", symbolSegment1.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
         assertEquals("      ", symbolSegment1.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals(SymbolType.CGM, symbolSegment1.getSymbolType());
         assertEquals(SymbolColour.UNKNOWN, symbolSegment1.getSymbolColour());
@@ -248,24 +248,5 @@ public class Nitf20OverflowTest {
         assertEquals(1, des7.getItemOverflowed());
 
         is.close();
-    }
-
-    void assertUnclasAndEmpty(SecurityMetadata securityMetadata) {
-        assertNotNull(securityMetadata);
-        assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
-        assertNull(securityMetadata.getSecurityClassificationSystem());
-        assertEquals("", securityMetadata.getCodewords());
-        assertEquals("", securityMetadata.getControlAndHandling());
-        assertEquals("", securityMetadata.getReleaseInstructions());
-        assertNull(securityMetadata.getDeclassificationType());
-        assertNull(securityMetadata.getDeclassificationDate());
-        assertNull(securityMetadata.getDeclassificationExemption());
-        assertNull(securityMetadata.getDowngrade());
-        assertNull(securityMetadata.getDowngradeDate());
-        assertNull(securityMetadata.getClassificationText());
-        assertNull(securityMetadata.getClassificationAuthorityType());
-        assertEquals("", securityMetadata.getClassificationAuthority());
-        assertNull(securityMetadata.getClassificationReason());
-        assertEquals("", securityMetadata.getSecurityControlNumber());
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20SymbolTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20SymbolTest.java
@@ -14,27 +14,24 @@
  **/
 package org.codice.imaging.nitf.core;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.time.format.DateTimeFormatter;
-
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf20SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.header.NitfFileParser;
 import org.codice.imaging.nitf.core.header.NitfHeader;
 import org.codice.imaging.nitf.core.security.FileSecurityMetadata;
-import org.codice.imaging.nitf.core.security.SecurityClassification;
-import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.symbol.SymbolColour;
 import org.codice.imaging.nitf.core.symbol.SymbolSegment;
 import org.codice.imaging.nitf.core.symbol.SymbolType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -96,7 +93,7 @@ public class Nitf20SymbolTest {
         assertEquals("1993-09-03 19:16:36", formatter.format(nitfHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("checks for rendering of polyline. line width 1, line type 3,4,5. def line type.", nitfHeader.getFileTitle());
         FileSecurityMetadata securityMetadata = nitfHeader.getFileSecurityMetadata();
-        assertUnclasAndEmpty(securityMetadata);
+        checkNitf20SecurityMetadataUnclasAndEmpty(securityMetadata);
         assertEquals("999998", securityMetadata.getDowngradeDateOrSpecialCase());
         assertEquals("This  file   will not need a downgrade.", securityMetadata.getDowngradeEvent());
         assertNull(securityMetadata.getSecuritySourceDate());
@@ -116,7 +113,7 @@ public class Nitf20SymbolTest {
         assertNotNull(symbolSegment1);
         assertEquals("0000000001", symbolSegment1.getIdentifier());
         assertEquals("multi.cgm  SYMBOL.", symbolSegment1.getSymbolName());
-        assertUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
+        checkNitf20SecurityMetadataUnclasAndEmpty(symbolSegment1.getSecurityMetadata());
         assertEquals("999998", symbolSegment1.getSecurityMetadata().getDowngradeDateOrSpecialCase());
         assertEquals("This symbol will never need downgrading.", symbolSegment1.getSecurityMetadata().getDowngradeEvent());
         assertEquals(SymbolType.CGM, symbolSegment1.getSymbolType());
@@ -133,24 +130,5 @@ public class Nitf20SymbolTest {
         assertEquals(0, symbolSegment1.getSymbolLocation2Column());
         assertEquals("000000", symbolSegment1.getSymbolNumber());
         assertEquals(0, symbolSegment1.getSymbolRotation());
-    }
-
-    private void assertUnclasAndEmpty(SecurityMetadata securityMetadata) {
-        assertNotNull(securityMetadata);
-        assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
-        assertNull(securityMetadata.getSecurityClassificationSystem());
-        assertEquals("", securityMetadata.getCodewords());
-        assertEquals("", securityMetadata.getControlAndHandling());
-        assertEquals("", securityMetadata.getReleaseInstructions());
-        assertNull(securityMetadata.getDeclassificationType());
-        assertNull(securityMetadata.getDeclassificationDate());
-        assertNull(securityMetadata.getDeclassificationExemption());
-        assertNull(securityMetadata.getDowngrade());
-        assertNull(securityMetadata.getDowngradeDate());
-        assertNull(securityMetadata.getClassificationText());
-        assertNull(securityMetadata.getClassificationAuthorityType());
-        assertEquals("", securityMetadata.getClassificationAuthority());
-        assertNull(securityMetadata.getClassificationReason());
-        assertEquals("", securityMetadata.getSecurityControlNumber());
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.xml.transform.stream.StreamSource;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf21SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileReader;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
@@ -47,7 +48,6 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
-import org.codice.imaging.nitf.core.security.SecurityClassification;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.text.TextFormat;
 import org.codice.imaging.nitf.core.text.TextSegment;
@@ -113,7 +113,7 @@ public class Nitf21HeaderTest {
         assertEquals("I_3034C", header.getOriginatingStationId());
         assertEquals("1997-12-18 12:15:39", formatter.format(header.getFileDateTime().getZonedDateTime()));
         assertEquals("Check an RGB/LUT 1 bit image maps black to red and white to green.", header.getFileTitle());
-        assertUnclasAndEmpty(header.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(header.getFileSecurityMetadata());
         assertEquals("00001", header.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00001", header.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals(0x20, header.getFileBackgroundColour().getRed());
@@ -135,7 +135,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment1.getImageTargetId().getOSuffix());
         assertEquals("  ", segment1.getImageTargetId().getCountryCode());
         assertEquals("- BASE IMAGE -", segment1.getImageIdentifier2());
-        assertUnclasAndEmpty(segment1.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(header.getFileSecurityMetadata());
         assertEquals("Unknown", segment1.getImageSource());
         assertEquals(18L, segment1.getNumberOfRows());
         assertEquals(35L, segment1.getNumberOfColumns());
@@ -203,7 +203,7 @@ public class Nitf21HeaderTest {
         assertEquals("i_3001a", nitfHeader.getOriginatingStationId());
         assertEquals("1997-12-17 10:26:30", formatter.format(nitfHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Checks an uncompressed 1024x1024 8 bit mono image with GEOcentric data. Airfield", nitfHeader.getFileTitle());
-        assertUnclasAndEmpty(nitfHeader.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(nitfHeader.getFileSecurityMetadata());
         assertEquals("00000", nitfHeader.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00000", nitfHeader.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals((byte) 0xFF, nitfHeader.getFileBackgroundColour().getRed());
@@ -225,7 +225,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment1.getImageTargetId().getOSuffix());
         assertEquals("  ", segment1.getImageTargetId().getCountryCode());
         assertEquals("- BASE IMAGE -", segment1.getImageIdentifier2());
-        assertUnclasAndEmpty(segment1.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment1.getSecurityMetadata());
         assertEquals("Unknown", segment1.getImageSource());
         assertEquals(1024L, segment1.getNumberOfRows());
         assertEquals(1024L, segment1.getNumberOfColumns());
@@ -275,7 +275,7 @@ public class Nitf21HeaderTest {
         assertEquals("NS3010A", nitfFileHeader.getOriginatingStationId());
         assertEquals("1997-12-17 16:00:28", formatter.format(nitfFileHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Checks a JPEG-compressed 231x191 8-bit mono image. blimp. Not divisable by 8.", nitfFileHeader.getFileTitle());
-        assertUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals((byte)0xFF, nitfFileHeader.getFileBackgroundColour().getRed());
@@ -297,7 +297,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment1.getImageTargetId().getOSuffix());
         assertEquals("  ", segment1.getImageTargetId().getCountryCode());
         assertEquals("This is an unclassified image in an unclassified NITF file Q3.", segment1.getImageIdentifier2());
-        assertUnclasAndEmpty(segment1.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment1.getSecurityMetadata());
         assertEquals("", segment1.getImageSource());
         assertEquals(191L, segment1.getNumberOfRows());
         assertEquals(231L, segment1.getNumberOfColumns());
@@ -345,7 +345,7 @@ public class Nitf21HeaderTest {
         assertEquals("NS3361c", nitfFileHeader.getOriginatingStationId());
         assertEquals("2000-12-12 12:12:12", formatter.format(nitfFileHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Boston_1 CONTAINS Four Sub-images lined up to show as a single image, dec data.", nitfFileHeader.getFileTitle());
-        assertUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals((byte)0x00, nitfFileHeader.getFileBackgroundColour().getRed());
@@ -367,7 +367,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment1.getImageTargetId().getOSuffix());
         assertEquals("US", segment1.getImageTargetId().getCountryCode());
         assertEquals("LOGAN AIRPORT BOSTON Located at 256,256, display level 4 first image file.", segment1.getImageIdentifier2());
-        assertUnclasAndEmpty(segment1.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment1.getSecurityMetadata());
         assertEquals("", segment1.getImageSource());
         assertEquals(256L, segment1.getNumberOfRows());
         assertEquals(256L, segment1.getNumberOfColumns());
@@ -400,7 +400,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment2.getImageTargetId().getOSuffix());
         assertEquals("US", segment2.getImageTargetId().getCountryCode());
         assertEquals("LOGAN AIRPORT BOSTON located at 000,256, display level 2, second image file.", segment2.getImageIdentifier2());
-        assertUnclasAndEmpty(segment2.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment2.getSecurityMetadata());
         assertEquals("", segment2.getImageSource());
         assertEquals(256L, segment2.getNumberOfRows());
         assertEquals(256L, segment2.getNumberOfColumns());
@@ -438,7 +438,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment3.getImageTargetId().getOSuffix());
         assertEquals("US", segment3.getImageTargetId().getCountryCode());
         assertEquals("LOGAN AIRPORT BOSTON located at 256,000, display level 3, third image file.", segment3.getImageIdentifier2());
-        assertUnclasAndEmpty(segment3.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment3.getSecurityMetadata());
         assertEquals("", segment3.getImageSource());
         assertEquals(256L, segment3.getNumberOfRows());
         assertEquals(256L, segment3.getNumberOfColumns());
@@ -471,7 +471,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", segment4.getImageTargetId().getOSuffix());
         assertEquals("US", segment4.getImageTargetId().getCountryCode());
         assertEquals("LOGAN AIRPORT BOSTON located at 000,000, display level 1, fourth image file.", segment4.getImageIdentifier2());
-        assertUnclasAndEmpty(segment4.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment4.getSecurityMetadata());
         assertEquals("", segment4.getImageSource());
         assertEquals(256L, segment4.getNumberOfRows());
         assertEquals(256L, segment4.getNumberOfColumns());
@@ -522,7 +522,7 @@ public class Nitf21HeaderTest {
         assertEquals(1, textSegment.getAttachmentLevel());
         assertEquals("1998-02-17 10:19:39", formatter.format(textSegment.getTextDateTime().getZonedDateTime()));
         assertEquals("                                                    Paragon Imaging Comment File", textSegment.getTextTitle());
-        assertUnclasAndEmpty(textSegment.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(textSegment.getSecurityMetadata());
         Assert.assertEquals(TextFormat.BASICCHARACTERSET, textSegment.getTextFormat());
     }
 
@@ -627,7 +627,7 @@ public class Nitf21HeaderTest {
         assertEquals("NS3051V", nitfFileHeader.getOriginatingStationId());
         assertEquals("1997-09-24 11:25:10", formatter.format(nitfFileHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Checks for new nitf 2.1 polygon set element, NIST polygonset test 06.", nitfFileHeader.getFileTitle());
-        assertUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00001", nitfFileHeader.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals(0, nitfFileHeader.getFileBackgroundColour().getRed());
@@ -644,7 +644,7 @@ public class Nitf21HeaderTest {
         assertNotNull(segment);
         assertEquals("POLYGONSET", segment.getIdentifier());
         assertEquals("POLYGON_SET", segment.getGraphicName());
-        assertUnclasAndEmpty(segment.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment.getSecurityMetadata());
         assertEquals(1, segment.getGraphicDisplayLevel());
         assertEquals(0, segment.getAttachmentLevel());
         assertEquals(1100, segment.getGraphicLocationRow());
@@ -674,7 +674,7 @@ public class Nitf21HeaderTest {
         assertEquals("I_3128b", nitfFileHeader.getOriginatingStationId());
         assertEquals("1999-02-10 14:01:44", formatter.format(nitfFileHeader.getFileDateTime().getZonedDateTime()));
         assertEquals("Checks an uncomp. 512x480 w/PIAPR_,PIAIM_ & 3 PIAPE_tags conf. to STD. Lab Gang.", nitfFileHeader.getFileTitle());
-        assertUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(nitfFileHeader.getFileSecurityMetadata());
         assertEquals("00000", nitfFileHeader.getFileSecurityMetadata().getFileCopyNumber());
         assertEquals("00000", nitfFileHeader.getFileSecurityMetadata().getFileNumberOfCopies());
         assertEquals(0, nitfFileHeader.getFileBackgroundColour().getRed());
@@ -733,7 +733,7 @@ public class Nitf21HeaderTest {
         assertEquals("     ", image.getImageTargetId().getOSuffix());
         assertEquals("  ", image.getImageTargetId().getCountryCode());
         assertEquals("- BASE IMAGE -", image.getImageIdentifier2());
-        assertUnclasAndEmpty(image.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(image.getSecurityMetadata());
         assertEquals("Unknown", image.getImageSource());
         assertEquals(480L, image.getNumberOfRows());
         assertEquals(512L, image.getNumberOfColumns());
@@ -825,7 +825,7 @@ public class Nitf21HeaderTest {
         assertNotNull(des);
         assertEquals("LIDARA DES", des.getIdentifier().trim());
         assertEquals(1, des.getDESVersion());
-        assertUnclasAndEmpty(des.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(des.getSecurityMetadata());
     }
 
     @Test
@@ -936,7 +936,7 @@ public class Nitf21HeaderTest {
         assertNotNull(segment1);
         assertEquals("30", segment1.getIdentifier());
         assertEquals("", segment1.getGraphicName());
-        assertUnclasAndEmpty(segment1.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment1.getSecurityMetadata());
         assertEquals(2, segment1.getGraphicDisplayLevel());
         assertEquals(0, segment1.getAttachmentLevel());
         assertEquals(326, segment1.getGraphicLocationRow());
@@ -950,7 +950,7 @@ public class Nitf21HeaderTest {
         assertNotNull(segment2);
         assertEquals("35", segment2.getIdentifier());
         assertEquals("", segment2.getGraphicName());
-        assertUnclasAndEmpty(segment2.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(segment2.getSecurityMetadata());
         assertEquals(3, segment2.getGraphicDisplayLevel());
         assertEquals(0, segment2.getAttachmentLevel());
         assertEquals(275, segment2.getGraphicLocationRow());
@@ -960,24 +960,6 @@ public class Nitf21HeaderTest {
         assertEquals(GraphicColour.COLOUR, segment2.getGraphicColour());
         assertEquals(345, segment2.getBoundingBox2Row());
         assertEquals(836, segment2.getBoundingBox2Column());
-    }
-
-    void assertUnclasAndEmpty(SecurityMetadata securityMetadata) {
-        Assert.assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
-        assertEquals("", securityMetadata.getSecurityClassificationSystem());
-        assertEquals("", securityMetadata.getCodewords());
-        assertEquals("", securityMetadata.getControlAndHandling());
-        assertEquals("", securityMetadata.getReleaseInstructions());
-        assertEquals("", securityMetadata.getDeclassificationType());
-        assertEquals("", securityMetadata.getDeclassificationDate());
-        assertEquals("", securityMetadata.getDeclassificationExemption());
-        assertEquals("", securityMetadata.getDowngrade());
-        assertEquals("", securityMetadata.getDowngradeDate());
-        assertEquals("", securityMetadata.getClassificationText());
-        assertEquals("", securityMetadata.getClassificationAuthorityType());
-        assertEquals("", securityMetadata.getClassificationAuthority());
-        assertEquals("", securityMetadata.getClassificationReason());
-        assertEquals("", securityMetadata.getSecurityControlNumber());
     }
 
     @After

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21SorcerTest.java
@@ -21,6 +21,7 @@ import java.text.ParseException;
 import java.time.format.DateTimeFormatter;
 import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf21SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.graphic.GraphicColour;
@@ -35,8 +36,6 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.core.image.PixelJustification;
 import org.codice.imaging.nitf.core.image.PixelValueType;
-import org.codice.imaging.nitf.core.security.SecurityClassification;
-import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.text.TextFormat;
 import org.codice.imaging.nitf.core.text.TextSegment;
 import static org.junit.Assert.assertEquals;
@@ -77,7 +76,7 @@ public class Nitf21SorcerTest {
         assertEquals("A1234", imageSegment.getImageTargetId().getOSuffix());
         assertEquals("AU", imageSegment.getImageTargetId().getCountryCode());
         assertEquals("Another title", imageSegment.getImageIdentifier2());
-        assertUnclasAndEmpty(imageSegment.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(imageSegment.getSecurityMetadata());
         assertEquals("", imageSegment.getImageSource());
         assertEquals(512L, imageSegment.getNumberOfRows());
         assertEquals(683L, imageSegment.getNumberOfColumns());
@@ -127,7 +126,7 @@ public class Nitf21SorcerTest {
         assertNotNull(graphicSegment);
         assertEquals("", graphicSegment.getIdentifier());
         assertEquals("", graphicSegment.getGraphicName());
-        assertUnclasAndEmpty(graphicSegment.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(graphicSegment.getSecurityMetadata());
         assertEquals(2, graphicSegment.getGraphicDisplayLevel());
         assertEquals(0, graphicSegment.getAttachmentLevel());
         assertEquals(12, graphicSegment.getGraphicLocationRow());
@@ -139,7 +138,7 @@ public class Nitf21SorcerTest {
         assertEquals(0, graphicSegment.getBoundingBox2Column());
 
         TextSegment textSegment = parseResult.getTextSegments().get(0);
-        assertUnclasAndEmpty(textSegment.getSecurityMetadata());
+        checkNitf21SecurityMetadataUnclasAndEmpty(textSegment.getSecurityMetadata());
         assertNotNull(textSegment);
         assertEquals("       ", textSegment.getIdentifier());
         assertEquals(0, textSegment.getAttachmentLevel());
@@ -154,24 +153,6 @@ public class Nitf21SorcerTest {
 
         assertNotNull("Test file missing", getClass().getResource(testfile));
         return getClass().getResourceAsStream(testfile);
-    }
-
-    void assertUnclasAndEmpty(SecurityMetadata securityMetadata) {
-        assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
-        assertEquals("", securityMetadata.getSecurityClassificationSystem());
-        assertEquals("", securityMetadata.getCodewords());
-        assertEquals("", securityMetadata.getControlAndHandling());
-        assertEquals("", securityMetadata.getReleaseInstructions());
-        assertEquals("", securityMetadata.getDeclassificationType());
-        assertEquals("", securityMetadata.getDeclassificationDate());
-        assertEquals("", securityMetadata.getDeclassificationExemption());
-        assertEquals("", securityMetadata.getDowngrade());
-        assertEquals("", securityMetadata.getDowngradeDate());
-        assertEquals("", securityMetadata.getClassificationText());
-        assertEquals("", securityMetadata.getClassificationAuthorityType());
-        assertEquals("", securityMetadata.getClassificationAuthority());
-        assertEquals("", securityMetadata.getClassificationReason());
-        assertEquals("", securityMetadata.getSecurityControlNumber());
     }
 
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/RoundTripGDALWriterTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/RoundTripGDALWriterTest.java
@@ -33,11 +33,6 @@ public class RoundTripGDALWriterTest extends AbstractWriterTest {
     }
 
     @Test
-    public void roundTripNITFrgb() throws ParseException, URISyntaxException, IOException {
-        roundTripFile("/fromGDAL/rgb.ntf");
-    }
-
-    @Test
     public void roundTripNITFtwoimages() throws ParseException, URISyntaxException, IOException {
         roundTripFile("/fromGDAL/two_images_jp2.ntf");
     }

--- a/core/src/test/java/org/codice/imaging/nitf/core/TestUtils.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/TestUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.codice.imaging.nitf.core.security.SecurityClassification;
+import org.codice.imaging.nitf.core.security.SecurityMetadata;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test utilities.
+ */
+public class TestUtils {
+
+    public TestUtils() {
+    }
+
+    public static void checkDateTimeIsRecent(ZonedDateTime zdt) {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        assertFalse(zdt.isAfter(now));
+        assertTrue(zdt.plusMinutes(1).isAfter(now));
+    }
+
+    public static void checkNitf20SecurityMetadataUnclasAndEmpty(SecurityMetadata securityMetadata) {
+        assertNotNull(securityMetadata);
+        assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
+        assertNull(securityMetadata.getSecurityClassificationSystem());
+        assertEquals("", securityMetadata.getCodewords());
+        assertEquals("", securityMetadata.getControlAndHandling());
+        assertEquals("", securityMetadata.getReleaseInstructions());
+        assertNull(securityMetadata.getDeclassificationType());
+        assertNull(securityMetadata.getDeclassificationDate());
+        assertNull(securityMetadata.getDeclassificationExemption());
+        assertNull(securityMetadata.getDowngrade());
+        assertNull(securityMetadata.getDowngradeDate());
+        assertNull(securityMetadata.getClassificationText());
+        assertNull(securityMetadata.getClassificationAuthorityType());
+        assertEquals("", securityMetadata.getClassificationAuthority());
+        assertNull(securityMetadata.getClassificationReason());
+        assertEquals("", securityMetadata.getSecurityControlNumber());
+    }
+
+    public static void checkNitf21SecurityMetadataUnclasAndEmpty(SecurityMetadata securityMetadata) {
+        Assert.assertEquals(SecurityClassification.UNCLASSIFIED, securityMetadata.getSecurityClassification());
+        assertEquals("", securityMetadata.getSecurityClassificationSystem());
+        assertEquals("", securityMetadata.getCodewords());
+        assertEquals("", securityMetadata.getControlAndHandling());
+        assertEquals("", securityMetadata.getReleaseInstructions());
+        assertEquals("", securityMetadata.getDeclassificationType());
+        assertEquals("", securityMetadata.getDeclassificationDate());
+        assertEquals("", securityMetadata.getDeclassificationExemption());
+        assertEquals("", securityMetadata.getDowngrade());
+        assertEquals("", securityMetadata.getDowngradeDate());
+        assertEquals("", securityMetadata.getClassificationText());
+        assertEquals("", securityMetadata.getClassificationAuthorityType());
+        assertEquals("", securityMetadata.getClassificationAuthority());
+        assertEquals("", securityMetadata.getClassificationReason());
+        assertEquals("", securityMetadata.getSecurityControlNumber());
+    }
+
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentParserTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/graphic/GraphicSegmentParserTest.java
@@ -125,7 +125,7 @@ public class GraphicSegmentParserTest {
     @Test
     public void testParse() throws ParseException {
         GraphicSegmentParser parser = new GraphicSegmentParser();
-        GraphicSegment header = parser.parse(nitfReader, strategy);
+        GraphicSegment header = parser.parse(nitfReader, strategy, 0);
         SecurityMetadata securityMetaData = header.getSecurityMetadata();
 
         assertThat(header, notNullValue());

--- a/core/src/test/java/org/codice/imaging/nitf/core/header/TestHeaderDefaultBuild.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/header/TestHeaderDefaultBuild.java
@@ -101,21 +101,6 @@ public class TestHeaderDefaultBuild {
 
         assertEquals("", nitf.getOriginatorsName());
         assertEquals("", nitf.getOriginatorsPhoneNumber());
-
-        assertEquals(0, nitf.getImageSegmentSubHeaderLengths().size());
-        assertEquals(0, nitf.getImageSegmentDataLengths().size());
-
-        assertEquals(0, nitf.getGraphicSegmentSubHeaderLengths().size());
-        assertEquals(0, nitf.getGraphicSegmentDataLengths().size());
-
-        assertEquals(0, nitf.getTextSegmentSubHeaderLengths().size());
-        assertEquals(0, nitf.getTextSegmentDataLengths().size());
-
-        assertEquals(0, nitf.getDataExtensionSegmentSubHeaderLengths().size());
-        assertEquals(0, nitf.getDataExtensionSegmentDataLengths().size());
-
-        assertEquals(0, nitf.getUserDefinedHeaderOverflow());
-        assertEquals(0, nitf.getExtendedHeaderDataOverflow());
     }
 
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/ImageSegmentParserTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/ImageSegmentParserTest.java
@@ -177,7 +177,7 @@ public class ImageSegmentParserTest {
     @Test
     public void testParse() throws ParseException {
         ImageSegmentParser parser = new ImageSegmentParser();
-        ImageSegment nitfImageSegmentHeader = parser.parse(nitfReader, strategy);
+        ImageSegment nitfImageSegmentHeader = parser.parse(nitfReader, strategy, 0);
 
         assertThat(nitfImageSegmentHeader.getImageMagnification(), is(IMAG));
         assertThat(nitfImageSegmentHeader.getImageMode(), is(ImageMode.BLOCKINTERLEVE));

--- a/core/src/test/java/org/codice/imaging/nitf/core/security/SecurityMetadataGenerationTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/security/SecurityMetadataGenerationTest.java
@@ -14,6 +14,8 @@
  */
 package org.codice.imaging.nitf.core.security;
 
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf20SecurityMetadataUnclasAndEmpty;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf21SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileType;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -30,33 +32,13 @@ public class SecurityMetadataGenerationTest {
 
     private void checkNITF21andNSIF10(SecurityMetadata defaultSecurityMetadata) {
         assertNotNull(defaultSecurityMetadata);
-        assertEquals(SecurityClassification.UNCLASSIFIED, defaultSecurityMetadata.getSecurityClassification());
-        assertEquals("  ", defaultSecurityMetadata.getSecurityClassificationSystem());
-        assertEquals("           ", defaultSecurityMetadata.getCodewords());
-        assertEquals("  ", defaultSecurityMetadata.getControlAndHandling());
-        assertEquals("                    ", defaultSecurityMetadata.getReleaseInstructions());
-        assertEquals("  ", defaultSecurityMetadata.getDeclassificationType());
-        assertEquals("        ", defaultSecurityMetadata.getDeclassificationDate());
-        assertEquals("    ", defaultSecurityMetadata.getDeclassificationExemption());
-        assertEquals(" ", defaultSecurityMetadata.getDowngrade());
-        assertEquals("        ", defaultSecurityMetadata.getDowngradeDate());
-        assertEquals("                                           ", defaultSecurityMetadata.getClassificationText());
-        assertEquals(" ", defaultSecurityMetadata.getClassificationAuthorityType());
-        assertEquals("                                        ", defaultSecurityMetadata.getClassificationAuthority());
-        assertEquals(" ", defaultSecurityMetadata.getClassificationReason());
-        assertEquals("        ", defaultSecurityMetadata.getSecuritySourceDate());
-        assertEquals("               ", defaultSecurityMetadata.getSecurityControlNumber());
+
+        checkNitf21SecurityMetadataUnclasAndEmpty(defaultSecurityMetadata);
     }
 
     private void checkNITF20(SecurityMetadata defaultSecurityMetadata) {
         assertNotNull(defaultSecurityMetadata);
-        assertEquals(SecurityClassification.UNCLASSIFIED, defaultSecurityMetadata.getSecurityClassification());
-        assertEquals("                                        ", defaultSecurityMetadata.getCodewords());
-        assertEquals("                                        ", defaultSecurityMetadata.getControlAndHandling());
-        assertEquals("                                        ", defaultSecurityMetadata.getReleaseInstructions());
-        assertEquals("                    ", defaultSecurityMetadata.getClassificationAuthority());
-        assertEquals("                    ", defaultSecurityMetadata.getSecurityControlNumber());
-        assertEquals("      ", defaultSecurityMetadata.getDowngradeDateOrSpecialCase());
+        checkNitf20SecurityMetadataUnclasAndEmpty(defaultSecurityMetadata);
         assertNull(defaultSecurityMetadata.getDowngradeEvent());
     }
 
@@ -83,8 +65,8 @@ public class SecurityMetadataGenerationTest {
         FileSecurityMetadata fsm = SecurityMetadataFactory.getDefaultFileSecurityMetadata(FileType.NITF_TWO_ONE);
         assertNotNull(fsm);
         checkNITF21andNSIF10(fsm);
-        assertEquals("     ", fsm.getFileCopyNumber());
-        assertEquals("     ", fsm.getFileNumberOfCopies());
+        assertEquals("", fsm.getFileCopyNumber());
+        assertEquals("", fsm.getFileNumberOfCopies());
     }
 
     @Test
@@ -92,8 +74,8 @@ public class SecurityMetadataGenerationTest {
         FileSecurityMetadata fsm = SecurityMetadataFactory.getDefaultFileSecurityMetadata(FileType.NSIF_ONE_ZERO);
         assertNotNull(fsm);
         checkNITF21andNSIF10(fsm);
-        assertEquals("     ", fsm.getFileCopyNumber());
-        assertEquals("     ", fsm.getFileNumberOfCopies());
+        assertEquals("", fsm.getFileCopyNumber());
+        assertEquals("", fsm.getFileNumberOfCopies());
     }
 
     @Test
@@ -101,7 +83,7 @@ public class SecurityMetadataGenerationTest {
         FileSecurityMetadata fsm = SecurityMetadataFactory.getDefaultFileSecurityMetadata(FileType.NITF_TWO_ZERO);
         assertNotNull(fsm);
         checkNITF20(fsm);
-        assertEquals("     ", fsm.getFileCopyNumber());
-        assertEquals("     ", fsm.getFileNumberOfCopies());
+        assertEquals("", fsm.getFileCopyNumber());
+        assertEquals("", fsm.getFileNumberOfCopies());
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/text/TestTextSegmentAddition.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/text/TestTextSegmentAddition.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.text;
+
+import java.io.File;
+import java.text.ParseException;
+import org.codice.imaging.nitf.core.AllDataExtractionParseStrategy;
+import org.codice.imaging.nitf.core.NitfDataSource;
+import org.codice.imaging.nitf.core.NitfFileWriter;
+import org.codice.imaging.nitf.core.SlottedMemoryNitfStorage;
+import org.codice.imaging.nitf.core.SlottedNitfParseStrategy;
+import org.codice.imaging.nitf.core.common.FileReader;
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.header.NitfFileParser;
+import org.codice.imaging.nitf.core.header.NitfHeader;
+import org.codice.imaging.nitf.core.header.NitfHeaderFactory;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * Test for adding / modifying test segments.
+ */
+public class TestTextSegmentAddition {
+
+    public TestTextSegmentAddition() {
+    }
+
+    @Test
+    public void writeSimpleHeader() throws ParseException {
+        final String OUTFILE_NAME = "textsegment_simple.ntf";
+        if (new File(OUTFILE_NAME).exists()) {
+            new File(OUTFILE_NAME).delete();
+        }
+
+        SlottedMemoryNitfStorage store = createBasicStore();
+        TextSegment textSegment = TextSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
+        textSegment.setTextTitle("Some Title");
+        textSegment.setData("This is the body.\r\nIt has two lines.");
+        textSegment.setTextFormat(TextFormat.getFormatUsedInString(textSegment.getData()));
+        store.getTextSegments().add(textSegment);
+        NitfFileWriter writer = new NitfFileWriter(store, OUTFILE_NAME);
+        writer.write();
+        NitfDataSource dataSource = verifyBasicHeader(OUTFILE_NAME);
+        assertEquals(0, dataSource.getImageSegments().size());
+        assertEquals(0, dataSource.getGraphicSegments().size());
+        assertEquals(1, dataSource.getTextSegments().size());
+        assertEquals(0, dataSource.getDataExtensionSegments().size());
+
+        TextSegment testSegment = dataSource.getTextSegments().get(0);
+        assertNotNull(testSegment);
+        assertEquals("Some Title", testSegment.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testSegment.getTextFormat()));
+        assertEquals("This is the body.\r\nIt has two lines.", testSegment.getData());
+        assertEquals(textSegment.getTextDateTime().getSourceString(), testSegment.getTextDateTime().getSourceString());
+
+        new File(OUTFILE_NAME).delete();
+    }
+
+    @Test
+    public void writeSegmentWithId() throws ParseException {
+        final String OUTFILE_NAME = "textsegment_withId.ntf";
+        if (new File(OUTFILE_NAME).exists()) {
+            new File(OUTFILE_NAME).delete();
+        }
+
+        SlottedMemoryNitfStorage store = createBasicStore();
+        TextSegment textSegment = TextSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
+        textSegment.setTextTitle("Some Title");
+        textSegment.setData("This is the body.\r\nIt has two lines.");
+        textSegment.setTextFormat(TextFormat.BASICCHARACTERSET);
+        textSegment.setIdentifier("XyZZy03");
+        store.getTextSegments().add(textSegment);
+        NitfFileWriter writer = new NitfFileWriter(store, OUTFILE_NAME);
+        writer.write();
+        NitfDataSource dataSource = verifyBasicHeader(OUTFILE_NAME);
+        assertEquals(0, dataSource.getImageSegments().size());
+        assertEquals(0, dataSource.getGraphicSegments().size());
+        assertEquals(1, dataSource.getTextSegments().size());
+        assertEquals(0, dataSource.getDataExtensionSegments().size());
+
+        TextSegment testSegment = dataSource.getTextSegments().get(0);
+        assertNotNull(testSegment);
+        assertEquals("XyZZy03", testSegment.getIdentifier());
+        assertEquals("Some Title", testSegment.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testSegment.getTextFormat()));
+        assertEquals("This is the body.\r\nIt has two lines.", testSegment.getData());
+        assertEquals(textSegment.getTextDateTime().getSourceString(), testSegment.getTextDateTime().getSourceString());
+
+        new File(OUTFILE_NAME).delete();
+    }
+
+    @Test
+    public void writeTwoTextSegments() throws ParseException {
+        final String OUTFILE_NAME = "twotextsegments.ntf";
+        TextSegment textSegment2 = makeTwoSegmentFile(OUTFILE_NAME);
+        NitfDataSource dataSource = verifyBasicHeader(OUTFILE_NAME);
+        assertEquals(0, dataSource.getImageSegments().size());
+        assertEquals(0, dataSource.getGraphicSegments().size());
+        assertEquals(2, dataSource.getTextSegments().size());
+        assertEquals(0, dataSource.getDataExtensionSegments().size());
+
+        TextSegment testSegment1 = dataSource.getTextSegments().get(0);
+        assertNotNull(testSegment1);
+        assertEquals("TXT001", testSegment1.getIdentifier().trim());
+        assertEquals("Some Title", testSegment1.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testSegment1.getTextFormat()));
+        assertEquals("This is the body.\r\nIt has two lines.", testSegment1.getData());
+
+        TextSegment testSegment2 = dataSource.getTextSegments().get(1);
+        assertNotNull(testSegment2);
+        assertEquals("TXT002", testSegment2.getIdentifier().trim());
+        assertEquals("A strange message", testSegment2.getTextTitle());
+        assertEquals(TextFormat.USMTF, testSegment2.getTextFormat());
+        assertEquals(textSegment2.getData(), testSegment2.getData());
+
+        new File(OUTFILE_NAME).delete();
+    }
+
+    @Test
+    public void modifyTwoTextSegments() throws ParseException {
+        final String OUTFILE_NAME = "twotextsegments_mod.ntf";
+        TextSegment textSegment2 = makeTwoSegmentFile(OUTFILE_NAME);
+        NitfDataSource dataSource = verifyBasicHeader(OUTFILE_NAME);
+        new File(OUTFILE_NAME).delete();
+
+        assertEquals(0, dataSource.getImageSegments().size());
+        assertEquals(0, dataSource.getGraphicSegments().size());
+        assertEquals(2, dataSource.getTextSegments().size());
+        assertEquals(0, dataSource.getDataExtensionSegments().size());
+
+        TextSegment testSegment1 = dataSource.getTextSegments().get(0);
+        assertNotNull(testSegment1);
+        assertEquals("TXT001", testSegment1.getIdentifier().trim());
+        assertEquals("Some Title", testSegment1.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testSegment1.getTextFormat()));
+        assertEquals("This is the body.\r\nIt has two lines.", testSegment1.getData());
+
+        TextSegment testSegment2 = dataSource.getTextSegments().get(1);
+        assertNotNull(testSegment2);
+        assertEquals("TXT002", testSegment2.getIdentifier().trim());
+        assertEquals("A strange message", testSegment2.getTextTitle());
+        assertEquals(TextFormat.USMTF, testSegment2.getTextFormat());
+        assertEquals(textSegment2.getData(), testSegment2.getData());
+
+        testSegment1.setData("A bit longer body.\nStill the body.\nIt has three lines.");
+        testSegment1.setIdentifier("Text001");
+        testSegment1.setTextTitle("A somewhat longer title");
+        assertEquals("Text001", dataSource.getTextSegments().get(0).getIdentifier());
+
+        testSegment2.setTextTitle("Motto");
+        testSegment2.setData("//GENTEXT/REMARKS/(U) TO LEAD. TO EXCEL.//");
+
+        final String OUTFILE_UPDATED_NAME = "twotextsegments_mod_updated.ntf";
+
+        NitfFileWriter writer = new NitfFileWriter(dataSource, OUTFILE_UPDATED_NAME);
+        writer.write();
+        NitfDataSource dataSourceUpdated = verifyBasicHeader(OUTFILE_UPDATED_NAME);
+        assertEquals(0, dataSourceUpdated.getImageSegments().size());
+        assertEquals(0, dataSourceUpdated.getGraphicSegments().size());
+        assertEquals(2, dataSourceUpdated.getTextSegments().size());
+        assertEquals(0, dataSourceUpdated.getDataExtensionSegments().size());
+        TextSegment testUpdated1 = dataSourceUpdated.getTextSegments().get(0);
+        assertNotNull(testUpdated1);
+        assertEquals("Text001", testUpdated1.getIdentifier().trim());
+        assertEquals("A somewhat longer title", testUpdated1.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testUpdated1.getTextFormat()));
+        assertEquals(testSegment1.getData(), testUpdated1.getData());
+
+        TextSegment testUpdated2 = dataSourceUpdated.getTextSegments().get(1);
+        assertNotNull(testUpdated2);
+        assertEquals("TXT002", testUpdated2.getIdentifier().trim());
+        assertEquals("Motto", testUpdated2.getTextTitle());
+        assertEquals(TextFormat.USMTF, testUpdated2.getTextFormat());
+        assertEquals("//GENTEXT/REMARKS/(U) TO LEAD. TO EXCEL.//", testUpdated2.getData());
+
+        new File(OUTFILE_UPDATED_NAME).delete();
+    }
+
+    @Test
+    public void deleteTextSegment() throws ParseException {
+        final String OUTFILE_NAME = "twotextsegments_delete.ntf";
+        TextSegment textSegment2 = makeTwoSegmentFile(OUTFILE_NAME);
+        NitfDataSource dataSource = verifyBasicHeader(OUTFILE_NAME);
+        new File(OUTFILE_NAME).delete();
+        assertEquals(0, dataSource.getImageSegments().size());
+        assertEquals(0, dataSource.getGraphicSegments().size());
+        assertEquals(2, dataSource.getTextSegments().size());
+        assertEquals(0, dataSource.getDataExtensionSegments().size());
+
+        TextSegment testSegment1 = dataSource.getTextSegments().get(0);
+        assertNotNull(testSegment1);
+        assertEquals("TXT001", testSegment1.getIdentifier().trim());
+        assertEquals("Some Title", testSegment1.getTextTitle());
+        assertTrue(TextFormat.BASICCHARACTERSET.equals(testSegment1.getTextFormat()));
+        assertEquals("This is the body.\r\nIt has two lines.", testSegment1.getData());
+
+        TextSegment testSegment2 = dataSource.getTextSegments().get(1);
+        assertNotNull(testSegment2);
+        assertEquals("TXT002", testSegment2.getIdentifier().trim());
+        assertEquals("A strange message", testSegment2.getTextTitle());
+        assertEquals(TextFormat.USMTF, testSegment2.getTextFormat());
+        assertEquals(textSegment2.getData(), testSegment2.getData());
+
+        dataSource.getTextSegments().remove(0);
+        final String OUTFILE_UPDATED_NAME = "twotextsegments_delete_updated.ntf";
+
+        NitfFileWriter writer = new NitfFileWriter(dataSource, OUTFILE_UPDATED_NAME);
+        writer.write();
+        NitfDataSource dataSourceUpdated = verifyBasicHeader(OUTFILE_UPDATED_NAME);
+        assertEquals(0, dataSourceUpdated.getImageSegments().size());
+        assertEquals(0, dataSourceUpdated.getGraphicSegments().size());
+        assertEquals(1, dataSourceUpdated.getTextSegments().size());
+        assertEquals(0, dataSourceUpdated.getDataExtensionSegments().size());
+        TextSegment updated = dataSource.getTextSegments().get(0);
+        assertNotNull(updated);
+        assertEquals("TXT002", updated.getIdentifier().trim());
+        assertEquals("A strange message", updated.getTextTitle());
+        assertEquals(TextFormat.USMTF, updated.getTextFormat());
+        assertEquals(textSegment2.getData(), updated.getData());
+        new File(OUTFILE_UPDATED_NAME).delete();
+    }
+
+    private TextSegment makeTwoSegmentFile(final String OUTFILE_NAME) {
+        if (new File(OUTFILE_NAME).exists()) {
+            new File(OUTFILE_NAME).delete();
+        }
+        SlottedMemoryNitfStorage store = createBasicStore();
+        TextSegment textSegment1 = TextSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
+        textSegment1.setTextTitle("Some Title");
+        textSegment1.setData("This is the body.\r\nIt has two lines.");
+        textSegment1.setTextFormat(TextFormat.BASICCHARACTERSET);
+        textSegment1.setIdentifier("TXT001");
+        store.getTextSegments().add(textSegment1);
+        TextSegment textSegment2 = TextSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
+        textSegment2.setIdentifier("TXT002");
+        textSegment2.setTextTitle("A strange message");
+        textSegment2.setTextFormat(TextFormat.USMTF);
+        textSegment2.setData("//GENTEXT/REMARKS/(U) THIS IS AN EXAMPLE USMTF  \nMESSAGE TEXT.//");
+        store.getTextSegments().add(textSegment2);
+        NitfFileWriter writer = new NitfFileWriter(store, OUTFILE_NAME);
+        writer.write();
+        return textSegment2;
+    }
+
+    private SlottedMemoryNitfStorage createBasicStore() {
+        SlottedMemoryNitfStorage store = new SlottedMemoryNitfStorage();
+        NitfHeader nitf = NitfHeaderFactory.getDefault(FileType.NITF_TWO_ONE);
+        assertNotNull(nitf);
+        assertEquals(FileType.NITF_TWO_ONE, nitf.getFileType());
+        store.setNitfHeader(nitf);
+        return store;
+    }
+
+    private NitfDataSource verifyBasicHeader(final String OUTFILE_NAME) throws ParseException {
+        FileReader reader = new FileReader(OUTFILE_NAME);
+        assertNotNull(reader);
+        SlottedNitfParseStrategy parseStrategy = new AllDataExtractionParseStrategy();
+        NitfFileParser.parse(reader, parseStrategy);
+        assertEquals(FileType.NITF_TWO_ONE, parseStrategy.getNitfHeader().getFileType());
+        return parseStrategy.getNitfDataSource();
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/text/TextSegmentFactoryTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/text/TextSegmentFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.text;
+
+import static org.codice.imaging.nitf.core.TestUtils.checkDateTimeIsRecent;
+import static org.codice.imaging.nitf.core.TestUtils.checkNitf21SecurityMetadataUnclasAndEmpty;
+import org.codice.imaging.nitf.core.common.FileType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+/**
+ * Tests for the TextSegmentFactory.
+ */
+public class TextSegmentFactoryTest {
+
+    public TextSegmentFactoryTest() {
+    }
+
+    @Test
+    public void NoText() {
+        TextSegment noTextSegment = TextSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
+        assertNotNull(noTextSegment);
+        assertEquals("", noTextSegment.getIdentifier());
+        assertEquals(0, noTextSegment.getAttachmentLevel());
+        checkDateTimeIsRecent(noTextSegment.getTextDateTime().getZonedDateTime());
+        assertEquals("", noTextSegment.getTextTitle());
+        checkNitf21SecurityMetadataUnclasAndEmpty(noTextSegment.getSecurityMetadata());
+        assertEquals(TextFormat.UTF8SUBSET, noTextSegment.getTextFormat());
+    }
+}


### PR DESCRIPTION
Associated changes include:
 - Tests, including some refactoring.
 - An API documentation note for spacing filling identifiers.
 - No longer storing header lengths in the NITF header