### PR TITLE
[IMG-151] Space pad out TargetId values.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentWriter.java
@@ -92,7 +92,7 @@ public class ImageSegmentWriter extends AbstractSegmentWriter {
         writeFixedLengthString(IM, IM.length());
         writeFixedLengthString(imageSegment.getIdentifier(), IID1_LENGTH);
         writeDateTime(imageSegment.getImageDateTime());
-        writeFixedLengthString(imageSegment.getImageTargetId().toString(), TGTID_LENGTH);
+        writeFixedLengthString(imageSegment.getImageTargetId().getAsText(), TGTID_LENGTH);
         writeFixedLengthString(imageSegment.getImageIdentifier2(), IID2_LENGTH);
         writeSecurityMetadata(imageSegment.getSecurityMetadata());
         writeENCRYP();

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/TargetId.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/TargetId.java
@@ -123,10 +123,30 @@ public class TargetId {
     }
 
     /**
-     * {@inheritDoc}
+     * Get the text equivalent of this target identifier.
+     *
+     * @return a space-padded string containing the target identifier.
+     * @throws NitfFormatException if any of the fields are null, or are too long to fit.
      */
-    @Override
-    public final String toString() {
-        return beNumber + oSuffix + countryCode;
+    public final String getAsText() throws NitfFormatException {
+        if (beNumber == null) {
+            throw new NitfFormatException("Cannot generate string target identifier with null BE number");
+        }
+        if (oSuffix == null) {
+            throw new NitfFormatException("Cannot generate string target identifier with null O-suffix");
+        }
+        if (countryCode == null) {
+            throw new NitfFormatException("Cannot generate string target identifier with null country code");
+        }
+        return padStringToLength(beNumber, BE_LENGTH)
+                + padStringToLength(oSuffix, OSUFFIX_LENGTH)
+                + padStringToLength(countryCode, COUNTRYCODE_LENGTH);
+    }
+
+    private String padStringToLength(final String s, final int length) throws NitfFormatException {
+        if (s.length() > length) {
+            throw new NitfFormatException("TargetId field value is too long");
+        }
+        return String.format("%1$-" + length + "s", s);
     }
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/ImageSegmentFactoryTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/ImageSegmentFactoryTest.java
@@ -34,7 +34,7 @@ public class ImageSegmentFactoryTest {
     }
 
     @Test
-    public void checkDefaultBuild() {
+    public void checkDefaultBuild() throws NitfFormatException {
         ImageSegment segment = ImageSegmentFactory.getDefault(FileType.NITF_TWO_ONE);
         assertNotNull(segment);
         assertEquals(FileType.NITF_TWO_ONE, segment.getFileType());
@@ -42,7 +42,7 @@ public class ImageSegmentFactoryTest {
         assertEquals("", segment.getIdentifier());
 
         assertNotNull(segment.getImageTargetId());
-        assertEquals("", segment.getImageTargetId().toString().trim());
+        assertEquals("", segment.getImageTargetId().getAsText().trim());
 
         assertEquals("", segment.getImageIdentifier2());
 
@@ -70,7 +70,7 @@ public class ImageSegmentFactoryTest {
 
         TargetId tgtid = new TargetId("ABCDEFGHIJUVWXYAU");
         segment.setImageTargetId(tgtid);
-        assertEquals(tgtid.toString(), segment.getImageTargetId().toString());
+        assertEquals(tgtid.getAsText(), segment.getImageTargetId().getAsText());
 
         segment.setImageIdentifier2("Secondary Identifier");
         assertEquals("Secondary Identifier", segment.getImageIdentifier2());

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/TargetIdTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/TargetIdTest.java
@@ -1,16 +1,16 @@
 /*
  * Copyright (c) Codice Foundation
- * 
+ *
  * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
  * General Public License as published by the Free Software Foundation, either version 3 of the
  * License, or any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
  * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
- * 
+ *
  */
 package org.codice.imaging.nitf.core.image;
 
@@ -32,7 +32,7 @@ public class TargetIdTest {
     }
 
     @Test
-    public void testTargetIdAccessors() {
+    public void testTargetIdAccessors() throws NitfFormatException {
         TargetId tgtid = new TargetId();
         assertNotNull(tgtid);
 
@@ -45,7 +45,30 @@ public class TargetIdTest {
         tgtid.setCountryCode("AU");
         assertEquals("AU", tgtid.getCountryCode());
 
-        assertEquals("ABCDEFGHIJUVWXYAU", tgtid.toString());
+        assertEquals("ABCDEFGHIJUVWXYAU", tgtid.getAsText());
+    }
+
+    @Test
+    public void testPartialFillCountryCode() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setCountryCode("AS");
+        assertEquals("               AS", targetId.getAsText());
+    }
+
+    @Test
+    public void testPartialFillOSuffix() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        // This example is a bit silly, but we're unit testing.
+        targetId.setOSuffix("UVWXY");
+        assertEquals("          UVWXY  ", targetId.getAsText());
+    }
+
+    @Test
+    public void testPartialFillBEandCountryCode() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setBasicEncyclopediaNumber("ABCDEFGHIJ");
+        targetId.setCountryCode("AS");
+        assertEquals("ABCDEFGHIJ     AS", targetId.getAsText());
     }
 
     @Test
@@ -72,5 +95,41 @@ public class TargetIdTest {
         exception.expect(NitfFormatException.class);
         exception.expectMessage("Incorrect length for TargetId:16");
         TargetId tgtid = new TargetId(targetIdArgument);
+    }
+
+    @Test
+    public void testToStringWithNullBE() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setBasicEncyclopediaNumber(null);
+        exception.expect(NitfFormatException.class);
+        exception.expectMessage("Cannot generate string target identifier with null BE number");
+        targetId.getAsText();
+    }
+
+    @Test
+    public void testToStringWithNullOSuffix() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setOSuffix(null);
+        exception.expect(NitfFormatException.class);
+        exception.expectMessage("Cannot generate string target identifier with null O-suffix");
+        targetId.getAsText();
+    }
+
+    @Test
+    public void testToStringWithNullCountryCode() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setCountryCode(null);
+        exception.expect(NitfFormatException.class);
+        exception.expectMessage("Cannot generate string target identifier with null country code");
+        targetId.getAsText();
+    }
+
+    @Test
+    public void testToStringWithTooLongBE() throws NitfFormatException {
+        TargetId targetId = new TargetId();
+        targetId.setBasicEncyclopediaNumber("ABCDEFGHIJK");
+        exception.expect(NitfFormatException.class);
+        exception.expectMessage("TargetId field value is too long");
+        targetId.getAsText();
     }
 }

--- a/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
+++ b/metadata-comparison/src/main/java/org/codice/nitf/metadatacomparison/FileComparer.java
@@ -328,7 +328,7 @@ public class FileComparer {
         metadata.put("NITF_ISSRDT", segment1.getSecurityMetadata().getSecuritySourceDate());
     }
 
-    private void addCommonImageSegmentMetadata(Map <String, String> metadata) throws IOException {
+    private void addCommonImageSegmentMetadata(Map<String, String> metadata) throws IOException, NitfFormatException {
         metadata.put("NITF_ABPP", String.format("%02d", segment1.getActualBitsPerPixelPerBand()));
         metadata.put("NITF_CCS_COLUMN", String.format("%d", segment1.getImageLocationColumn()));
         metadata.put("NITF_CCS_ROW", String.format("%d", segment1.getImageLocationRow()));
@@ -372,7 +372,7 @@ public class FileComparer {
         metadata.put("NITF_PJUST", segment1.getPixelJustification().getTextEquivalent());
         metadata.put("NITF_PVTYPE", segment1.getPixelValueType().getTextEquivalent());
         if (segment1.getImageTargetId().toString().length() > 0) {
-            metadata.put("NITF_TGTID", rightTrim(segment1.getImageTargetId().toString()));
+            metadata.put("NITF_TGTID", rightTrim(segment1.getImageTargetId().getAsText()));
         } else {
             metadata.put("NITF_TGTID", "");
         }


### PR DESCRIPTION
This required moving away from toString(), to support better checking.

@dcruver 