### PR TITLE
[IMG-131/132/133/135] Add parsing for PIAEQA, PIAEVA, PIAPEB and PIATGB

### DIFF
--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -589,6 +589,11 @@
         <field name="OBJVIEW" length="6" type="string"/>
     </tre>
 
+    <tre name="PIAEVA" length="46">
+        <field name="EVENTNAME" length="38" type="string"/>
+        <field name="EVENTTYPE" length="8" type="string"/>
+    </tre>
+
     <tre name="PIAIMB" md_prefix="NITF_PIAIMB_" length="337" location="image">
         <field name="CLOUDCVR" length="3"/>
         <field name="SRP" length="1"/>

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -640,6 +640,14 @@
         <field name="ASSOCTRY" length="2" type="string"/>
     </tre>
 
+    <tre name="PIAPEB" length="94" location="image">
+        <field name="LASTNME" length="28" type="string"/>
+        <field name="FIRSTNME" length="28" type="string"/>
+        <field name="MIDNME" length="28" type="string"/>
+        <field name="DOB" length="8" type="string"/>
+        <field name="ASSOCTRY" length="2" type="string"/>
+    </tre>
+
     <tre name="PIAPRC" minlength="201" maxlength="63759" location="file"> <!-- same as PIAPRD apparently ? -->
         <field name="ACCESSID" length="64" type="string"/>
         <field name="FMCONTROL" length="32" type="string"/>

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -718,6 +718,19 @@
         </loop>
     </tre>
 
+    <tre name="PIATGB" length="117">
+        <field name="TGTUTM" length="15" type="string"/>
+        <field name="PIATGAID" length="15" type="string"/>
+        <field name="PIACTRY" length="2" type="string"/>
+        <field name="PIACAT" length="5" type="string"/>
+        <field name="TGTGEO" length="15" type="string"/>
+        <field name="DATUM" length="3" type="string"/>
+        <field name="TGTNAME" length="38" type="string"/>
+        <field name="PERCOVER" length="3" type="integer"/>
+        <field name="TGTLAT" length="10" type="real"/>
+        <field name="TGTLON" length="11" type="real"/>
+    </tre>
+
     <tre name="PRJPSB" minlength="113" maxlength="248" location="file">
         <field name="PRN" length="80" type="string"/>
         <field name="PCO" length="2" type="string"/>

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -578,6 +578,17 @@
         <field name="BATCH_NO" length="6" type="string"/>
     </tre>
 
+    <tre name="PIAEQA" length="130">
+        <field name="EQPCODE" length="7" type="string"/>
+        <field name="EQPNOMEN" length="45" type="string"/>
+        <field name="EQPMAN" length="64" type="string"/>
+        <field name="OBTYPE" length="1" type="string"/>
+        <field name="ORDBAT" length="3" type="string"/>
+        <field name="CTRYPROD" length="2" type="string"/>
+        <field name="CTRYDSN" length="2" type="string"/>
+        <field name="OBJVIEW" length="6" type="string"/>
+    </tre>
+
     <tre name="PIAIMB" md_prefix="NITF_PIAIMB_" length="337" location="image">
         <field name="CLOUDCVR" length="3"/>
         <field name="SRP" length="1"/>

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAEQA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAEQA_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for PIAEQA TRE parsing.
+ *
+ * This TRE is described in STDI-0002 Annex C, Section C.6.
+ *
+ */
+public class PIAEQA_Test extends SharedTreTest {
+    
+    public PIAEQA_Test() {
+    }
+
+    @Test
+    public void SimplePIAEQA() throws Exception {
+        String treTag = "PIAEQA";
+        String testData = "PIAEQA00130A123456TECHNICAL(UNKNOWN)1234567890ABCDEFGHIJKMNOPQRSOME MANUFACTURER. Some padding for length and testing purposes.XABCYAZCBottom";
+        int expectedLength = treTag.length() + "00130".length() + 130;
+        
+        Tre piaeqa = parseTRE(testData, expectedLength, treTag);
+        assertEquals(8, piaeqa.getEntries().size());
+        assertEquals("A123456", piaeqa.getFieldValue("EQPCODE"));
+        assertEquals("TECHNICAL(UNKNOWN)1234567890ABCDEFGHIJKMNOPQR", piaeqa.getFieldValue("EQPNOMEN"));
+        assertEquals("SOME MANUFACTURER. Some padding for length and testing purposes.", piaeqa.getFieldValue("EQPMAN"));
+        assertEquals("X", piaeqa.getFieldValue("OBTYPE"));
+        assertEquals("ABC", piaeqa.getFieldValue("ORDBAT"));
+        assertEquals("YA", piaeqa.getFieldValue("CTRYPROD"));
+        assertEquals("ZC", piaeqa.getFieldValue("CTRYDSN"));
+        assertEquals("Bottom", piaeqa.getFieldValue("OBJVIEW"));
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAEVA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAEVA_Test.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for PIAEVA TRE parsing.
+ *
+ * This TRE is described in STDI-0002 Annex C, Section C.5.
+ *
+ */
+public class PIAEVA_Test extends SharedTreTest {
+    
+    public PIAEVA_Test() {
+    }
+
+    @Test
+    public void SimplePIAEVA() throws Exception {
+        String treTag = "PIAEVA";
+        String testData = "PIAEVA00046Dawn at Ceres                         SPACE   ";
+        int expectedLength = treTag.length() + "00046".length() + 46;
+        
+        Tre piaeva = parseTRE(testData, expectedLength, treTag);
+        assertEquals(2, piaeva.getEntries().size());
+        assertEquals("Dawn at Ceres                         ", piaeva.getFieldValue("EVENTNAME"));
+        assertEquals("SPACE   ", piaeva.getFieldValue("EVENTTYPE"));
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAPEB_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/PIAPEB_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.common.NitfReader;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for PIAPEB TRE parsing.
+ *
+ * This TRE is described in STDI-0002 Annex C, Section C.4.
+ *
+ */
+public class PIAPEB_Test extends SharedTreTest {
+    
+    public PIAPEB_Test() {
+    }
+
+    @Test
+    public void SimplePIAPEB() throws Exception {
+        String treTag = "PIAPEB";
+        String testData = "PIAPEB00094Maxwell                     James                       Clerk                       18310613UK";
+        int expectedLength = treTag.length() + "00094".length() + 94;
+        
+        Tre piapeb = parseTRE(testData, expectedLength, treTag);
+        assertEquals(5, piapeb.getEntries().size());
+        assertEquals("Maxwell", piapeb.getFieldValue("LASTNME").trim());
+        assertEquals("James", piapeb.getFieldValue("FIRSTNME").trim());
+        assertEquals("Clerk", piapeb.getFieldValue("MIDNME").trim());
+        assertEquals("18310613", piapeb.getFieldValue("DOB"));
+        assertEquals("UK", piapeb.getFieldValue(("ASSOCTRY")));
+    }
+
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/PIATGB_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/PIATGB_Test.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for PIATGB TRE parsing.
+ *
+ * This TRE is described in STDI-0002 Annex C, Section C.3.
+ *
+ */
+public class PIATGB_Test extends SharedTreTest {
+    
+    public PIATGB_Test() {
+    }
+
+    @Test
+    public void SimplePIATGB() throws Exception {
+        String treTag = "PIATGB";
+        String testData = "PIATGB0011755HFA9359093610ABCDEFGHIJUVWXYAS702XX351655S1490742EWGECanberra Hill                         057-35.30812 +149.12447 ";
+        int expectedLength = treTag.length() + "00117".length() + 117;
+        
+        Tre piatgb = parseTRE(testData, expectedLength, treTag);
+        assertEquals(10, piatgb.getEntries().size());
+        assertEquals("55HFA9359093610", piatgb.getFieldValue("TGTUTM"));
+        assertEquals("ABCDEFGHIJUVWXY", piatgb.getFieldValue("PIATGAID"));
+        assertEquals("AS", piatgb.getFieldValue("PIACTRY"));
+        assertEquals("702XX", piatgb.getFieldValue("PIACAT"));
+        assertEquals("351655S1490742E", piatgb.getFieldValue("TGTGEO"));
+        assertEquals("WGE", piatgb.getFieldValue("DATUM"));
+        assertEquals("Canberra Hill                         ", piatgb.getFieldValue("TGTNAME"));
+        assertEquals(57, piatgb.getIntValue("PERCOVER"));
+        assertEquals("-35.30812 ", piatgb.getFieldValue("TGTLAT"));
+        assertEquals("+149.12447 ", piatgb.getFieldValue("TGTLON"));
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/SharedTreTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/SharedTreTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.common.NitfReader;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Shared test code for TRE tests.
+ */
+class SharedTreTest {
+    
+    protected Tre parseTRE(String testData, int expectedLength, String treTag) throws NitfFormatException {
+        InputStream inputStream = new ByteArrayInputStream(testData.getBytes());
+        BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        TreCollection parseResult = parser.parse(nitfReader, expectedLength, TreSource.ImageExtendedSubheaderData);
+        assertEquals(1, parseResult.getTREs().size());
+        Tre tre = parseResult.getTREsWithName(treTag).get(0);
+        assertNotNull(tre);
+        return tre;
+    }
+
+}


### PR DESCRIPTION
These are pretty simple TREs from STDI-0002 Appendix C. They are the missing
parts from the NITF Profile for Imagery Access Image Support Extensions
(PIAE Version 3.0/CN1).

More meaningful support (e.g. higher level wrappers) may be hard because the
controlled vocabulary is not public.