### PR TITLE
[IMG-152] Fix tests on Windows when parent directory contains a space.

### DIFF
--- a/core/src/test/java/org/codice/imaging/nitf/core/FileReaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/FileReaderTest.java
@@ -36,7 +36,7 @@ public class FileReaderTest {
     public void testBadFilenameConstructorArgument() throws NitfFormatException, URISyntaxException {
         assertNotNull("Test file missing", getClass().getResource(testfile));
 
-        FileReader goodReader = new FileReader(getClass().getResource(testfile).getPath());
+        FileReader goodReader = new FileReader(getClass().getResource(testfile).toURI().getPath());
         assertNotNull(goodReader);
 
         exception.expect(NitfFormatException.class);

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf20HeaderTest.java
@@ -18,6 +18,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.time.format.DateTimeFormatter;
 import static org.codice.imaging.nitf.core.TestUtils.checkNitf20SecurityMetadataUnclasAndEmpty;
 import org.codice.imaging.nitf.core.common.FileReader;
@@ -73,12 +74,12 @@ public class Nitf20HeaderTest {
     }
 
     @Test
-    public void testCompliantHeaderReadFile() throws IOException, NitfFormatException {
+    public void testCompliantHeaderReadFile() throws IOException, NitfFormatException, URISyntaxException {
         final String simpleNitf20File = "/JitcNitf20Samples/U_1114A.NTF";
 
         assertNotNull("Test file missing", getClass().getResource(simpleNitf20File));
 
-        File resourceFile = new File(getClass().getResource(simpleNitf20File).getFile());
+        File resourceFile = new File(getClass().getResource(simpleNitf20File).toURI().getPath());
         SlottedParseStrategy parseStrategy = new SlottedParseStrategy(SlottedParseStrategy.TEXT_DATA);
         NitfReader reader = new FileReader(resourceFile);
         NitfParser.parse(reader, parseStrategy);

--- a/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/Nitf21HeaderTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URISyntaxException;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -94,11 +95,11 @@ public class Nitf21HeaderTest {
     }
 
     @Test
-    public void testCompliantHeaderReadFile() throws IOException, NitfFormatException {
+    public void testCompliantHeaderReadFile() throws IOException, NitfFormatException, URISyntaxException {
         final String simpleNitf21File = "/JitcNitf21Samples/i_3034c.ntf";
         assertNotNull("Test file missing", getClass().getResource(simpleNitf21File));
 
-        File resourceFile = new File(getClass().getResource(simpleNitf21File).getFile());
+        File resourceFile = new File(getClass().getResource(simpleNitf21File).toURI().getPath());
         SlottedParseStrategy parseStrategy = new SlottedParseStrategy(SlottedParseStrategy.HEADERS_ONLY);
         NitfReader reader = new FileReader(resourceFile);
         NitfParser.parse(reader, parseStrategy);
@@ -580,11 +581,11 @@ public class Nitf21HeaderTest {
     }
 
     @Test
-    public void testStreamingModeParsingFromFile() throws IOException, NitfFormatException {
+    public void testStreamingModeParsingFromFile() throws IOException, NitfFormatException, URISyntaxException {
         final String testfile = "/JitcNitf21Samples/ns3321a.nsf";
         assertNotNull("Test file missing", getClass().getResource(testfile));
 
-        File resourceFile = new File(getClass().getResource(testfile).getFile());
+        File resourceFile = new File(getClass().getResource(testfile).toURI().getPath());
         SlottedParseStrategy parseStrategy = new SlottedParseStrategy(SlottedParseStrategy.HEADERS_ONLY);
         NitfReader reader = new FileReader(resourceFile);
         NitfParser.parse(reader, parseStrategy);

--- a/core/src/test/java/org/codice/imaging/nitf/core/StreamingModeTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/StreamingModeTest.java
@@ -44,7 +44,7 @@ public class StreamingModeTest {
         String outputFile = FilenameUtils.getName(testfile);
         assertNotNull("Test file missing", getClass().getResource(testfile));
 
-        File resourceFile = new File(getClass().getResource(testfile).getFile());
+        File resourceFile = new File(getClass().getResource(testfile).toURI().getPath());
         SlottedParseStrategy parseStrategy = new SlottedParseStrategy(SlottedParseStrategy.ALL_SEGMENT_DATA);
         NitfReader reader = new FileReader(resourceFile);
         NitfParser.parse(reader, parseStrategy);


### PR DESCRIPTION
The Java behaviour for a URL (from getResource()) is to percent encode, which breaks file operations.
I've switched to a URI, which doesn't do this.