### PR TITLE
[IMG-172] Add extra IC values for MIE4NITF.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageCompression.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageCompression.java
@@ -15,8 +15,12 @@
 package org.codice.imaging.nitf.core.image;
 
 /**
-    Image compression format.
-*/
+ * Image compression (IC) format.
+ *
+ * Note that some format options are only valid in motion imagery (MIE4NITF),
+ * and that there is coupling between the ImageMode (IMODE) property and this
+ * compression property.
+ */
 public enum ImageCompression {
 
     /**
@@ -146,6 +150,7 @@ public enum ImageCompression {
         This is not valid for NITF 2.0 files.
     */
     JPEG2000 ("C8"),
+
     /**
         JPEG 2000 mask.
         <p>
@@ -153,7 +158,61 @@ public enum ImageCompression {
         <p>
         This is not valid for NITF 2.0 files.
     */
-    JPEG2000MASK ("M8");
+    JPEG2000MASK ("M8"),
+
+    /**
+     * Blocked H.264 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    H264MASK ("M9"),
+
+    /**
+     * Blocked H.265 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    H265MASK ("MA"),
+
+    /**
+     * H.264 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    H264 ("C9"),
+
+    /**
+     * H.265 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    H265 ("CA"),
+
+    /**
+     * Blocked JPEG2000 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    JPEG2000MASKTIME ("MB"),
+
+    /**
+     * JPEG2000 with time.
+     *
+     * This field value is from the Motion Imagery Extensions for NITF (MIE4NITF)
+     * version 1.1, table 16. This is only valid if the image segment holds
+     * motion imagery.
+     */
+    JPEG2000TIME ("CB");
 
     private final String textEquivalent;
 
@@ -179,7 +238,7 @@ public enum ImageCompression {
     */
     public static ImageCompression getEnumValue(final String textEquivalent) {
         for (ImageCompression ic : values()) {
-            if (textEquivalent.equals(ic.textEquivalent)) {
+            if (ic.textEquivalent.equals(textEquivalent)) {
                 return ic;
             }
         }

--- a/core/src/test/java/org/codice/imaging/nitf/core/image/ImageCompressionTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/image/ImageCompressionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.image;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ * Tests for ImageCompression enumeration.
+ */
+public class ImageCompressionTest {
+
+    public ImageCompressionTest() {
+    }
+
+    @Test
+    public void checkUnknownConversion() {
+        assertEquals(ImageCompression.UNKNOWN, ImageCompression.getEnumValue(""));
+        assertEquals(ImageCompression.UNKNOWN, ImageCompression.getEnumValue(null));
+        assertEquals(ImageCompression.UNKNOWN, ImageCompression.getEnumValue("xyzzy"));
+    }
+
+    @Test
+    public void checkMotionImageryExtensions() {
+        assertEquals(ImageCompression.H264, ImageCompression.getEnumValue("C9"));
+        assertEquals(ImageCompression.H265, ImageCompression.getEnumValue("CA"));
+        assertEquals(ImageCompression.H264MASK, ImageCompression.getEnumValue("M9"));
+        assertEquals(ImageCompression.H265MASK, ImageCompression.getEnumValue("MA"));
+        assertEquals(ImageCompression.JPEG2000MASKTIME, ImageCompression.getEnumValue("MB"));
+        assertEquals(ImageCompression.JPEG2000TIME, ImageCompression.getEnumValue("CB"));
+    }
+
+    @Test
+    public void checkJPEG2000() {
+        assertEquals(ImageCompression.JPEG2000, ImageCompression.getEnumValue("C8"));
+        assertEquals(ImageCompression.JPEG2000MASK, ImageCompression.getEnumValue("M8"));
+        assertEquals("C8", ImageCompression.JPEG2000.getTextEquivalent());
+        assertEquals("M8", ImageCompression.JPEG2000MASK.getTextEquivalent());
+    }
+
+    @Test
+    public void checkUncompressed() {
+        assertEquals(ImageCompression.NOTCOMPRESSED, ImageCompression.getEnumValue("NC"));
+        assertEquals(ImageCompression.NOTCOMPRESSEDMASK, ImageCompression.getEnumValue("NM"));
+        assertEquals("NC", ImageCompression.NOTCOMPRESSED.getTextEquivalent());
+        assertEquals("NM", ImageCompression.NOTCOMPRESSEDMASK.getTextEquivalent());
+    }
+}


### PR DESCRIPTION
Basically this allows storing motion imagery frames in a single image segment.