### PR TITLE
img-175 handle 'NOTFORDISPLAY' images gracefully.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -44,6 +44,8 @@ public final class ImageRepresentationHandlerFactory {
     public static ImageRepresentationHandler forImageSegment(final ImageSegment segment) {
 
         switch (segment.getImageRepresentation()) {
+            case NOTFORDISPLAY:
+                return new NoDisplayImageRepresentationHandler();
             case MONOCHROME:
                 return getMonoImageRepresentationHandler(segment, 0);
             case RGBTRUECOLOUR:

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/NoDisplayImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/NoDisplayImageRepresentationHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagerep;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.io.IOException;
+
+import javax.imageio.stream.ImageInputStream;
+
+import org.codice.imaging.nitf.render.ImageMask;
+
+public class NoDisplayImageRepresentationHandler implements ImageRepresentationHandler {
+    @Override
+    public void renderPixelBand(DataBuffer dataBuffer, int pixelIndex,
+            ImageInputStream imageInputStream, int bandIndex) throws IOException {
+        return;
+    }
+
+    @Override
+    public BufferedImage createBufferedImage(int width, int height) {
+        return new BufferedImage(width, height, BufferedImage.TYPE_BYTE_GRAY);
+    }
+
+    @Override
+    public void renderPadPixel(ImageMask imageMask, DataBuffer data, int pixelIndex) {
+        return;
+    }
+}


### PR DESCRIPTION
This change adds an no-op implmenetation of ImageRepresentationHandler for images with an ImageRepresentation value of
'NOTFORDISPLAY'.  Previously, the NitfRenderer class threw an exception when encountering this ImageRepresentation type.

@bradh 
@kcwire 