### PR TITLE
[IMG-168] Implement MTIMSA, part of MIE4NITF.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/NitfReaderDefaultImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/NitfReaderDefaultImpl.java
@@ -15,6 +15,7 @@
 package org.codice.imaging.nitf.core;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.common.NitfReader;
@@ -159,7 +160,7 @@ public abstract class NitfReaderDefaultImpl implements NitfReader {
         @throws NitfFormatException if something went wrong during parsing (e.g. end of file).
     */
     protected final String defaultReadBytes(final int count) throws NitfFormatException {
-        return new String(readBytesRaw(count), UTF8_CHARSET);
+        return new String(readBytesRaw(count), StandardCharsets.ISO_8859_1);
     }
 
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreEntry.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreEntry.java
@@ -30,19 +30,22 @@ public class TreEntry {
 
     private String name = null;
     private String value = null;
+    private String dataType = null;
     private List<TreGroup> groups = null;
 
     /**
-        Construct a TRE entry with a specific field name, field value and parent.
-        <p>
-        This is the simple (not-repeating) TRE entry form.
-
-        @param fieldName the field name of the new TRE entry.
-        @param fieldValue the field value for the new TRE entry.
+     * Construct a TRE entry with a specific field name, field value and parent.
+     * <p>
+     * This is the simple (not-repeating) TRE entry form.
+     *
+     * @param fieldName the field name of the new TRE entry.
+     * @param fieldValue the field value for the new TRE entry.
+     * @param fieldType the data type ("string", "real", "UINT8", "integer") for the data
     */
-    public TreEntry(final String fieldName, final String fieldValue) {
+    public TreEntry(final String fieldName, final String fieldValue, final String fieldType) {
         name = fieldName;
         value = fieldValue;
+        dataType = fieldType;
     }
 
     /**
@@ -118,6 +121,17 @@ public class TreEntry {
     */
     public final void addGroup(final TreGroup group) {
         groups.add(group);
+    }
+
+    /**
+     * Return the data type for this TRE entry.
+     *
+     * This is only meaningful if it is a simple entry (not a nested group).
+     *
+     * @return the data type as a string, or null for a group.
+     */
+    public final String getDataType() {
+        return dataType;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroup.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroup.java
@@ -14,6 +14,7 @@
  **/
 package org.codice.imaging.nitf.core.tre;
 
+import java.math.BigInteger;
 import java.util.List;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 
@@ -71,10 +72,39 @@ public interface TreGroup {
      Get the field value for a specific tag in integer format.
 
      @param tagName the name (tag) of the field to look up.
-     @return the field value corresponding to the tag name, as an integer.
+     @return the field value corresponding to the tag name, as a integer.
      @throws NitfFormatException when the tag is not found or the value cannot be converted to integer format.
      */
     int getIntValue(String tagName) throws NitfFormatException;
+
+    /**
+     * Get the field value for a specific tag in long integer format.
+     *
+     * @param tagName the name (tag) of the field to look up.
+     * @return the field value corresponding to the tag name, as a long integer.
+     * @throws NitfFormatException when the tag is not found or the value cannot
+     * be converted to long integer format.
+     */
+    long getLongIntegerValue(String tagName) throws NitfFormatException;
+
+    /**
+     * Get the field value for a specific tag as a BigInteger.
+     *
+     * @param tagName the name (tag) of the field to look up.
+     * @return the field value corresponding to the tag name.
+     * @throws NitfFormatException when the tag is not found or the value cannot
+     * be converted to a number format.
+     */
+    BigInteger getBigIntegerValue(String tagName) throws NitfFormatException;
+
+    /**
+     * Get the field value for a specific tag in double format.
+     *
+     * @param tagName the name (tag) of the field to look up.
+     * @return the field value corresponding to the tag name, as an double.
+     * @throws NitfFormatException when the tag is not found or the value cannot be converted to double format.
+     */
+    double getDoubleValue(String tagName) throws NitfFormatException;
 
     /**
      Debug dump of the entries.

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroup.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroup.java
@@ -85,7 +85,7 @@ public interface TreGroup {
      * @throws NitfFormatException when the tag is not found or the value cannot
      * be converted to long integer format.
      */
-    long getLongIntegerValue(String tagName) throws NitfFormatException;
+    long getLongValue(String tagName) throws NitfFormatException;
 
     /**
      * Get the field value for a specific tag as a BigInteger.

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroupImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroupImpl.java
@@ -14,10 +14,11 @@
  **/
 package org.codice.imaging.nitf.core.tre;
 
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,11 +96,44 @@ class TreGroupImpl implements TreGroup {
      */
     @Override
     public final int getIntValue(final String tagName) throws NitfFormatException {
+        return getBigIntegerValue(tagName).intValueExact();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final long getLongIntegerValue(final String tagName) throws NitfFormatException {
+        return getBigIntegerValue(tagName).longValueExact();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final BigInteger getBigIntegerValue(final String tagName) throws NitfFormatException {
         try {
-            String fv = getFieldValue(tagName);
-            return Integer.parseInt(fv, DECIMAL_BASE);
+            TreEntry entry = getEntry(tagName);
+            if (entry.getDataType().equals("UINT")) {
+                return new BigInteger(1, entry.getFieldValue().getBytes(StandardCharsets.ISO_8859_1));
+            } else {
+                return new BigInteger(entry.getFieldValue(), DECIMAL_BASE);
+            }
         } catch (NitfFormatException ex) {
-            throw new NitfFormatException(String.format("Failed to look up %s as integer value", tagName));
+            throw new NitfFormatException(String.format("Failed to look up %s as a numerical value", tagName));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final double getDoubleValue(final String tagName) throws NitfFormatException {
+        try {
+            TreEntry entry = getEntry(tagName);
+            return Double.parseDouble(entry.getFieldValue());
+        } catch (NitfFormatException ex) {
+            throw new NitfFormatException(String.format("Failed to look up %s as double value", tagName));
         }
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroupImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreGroupImpl.java
@@ -103,7 +103,7 @@ class TreGroupImpl implements TreGroup {
      * {@inheritDoc}
      */
     @Override
-    public final long getLongIntegerValue(final String tagName) throws NitfFormatException {
+    public final long getLongValue(final String tagName) throws NitfFormatException {
         return getBigIntegerValue(tagName).longValueExact();
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreParams.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreParams.java
@@ -11,24 +11,49 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
- **/
+ *
+ */
 package org.codice.imaging.nitf.core.tre;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 class TreParams {
-    private final Map<String, String> parameters = new HashMap<>();
+
+    private final Map<String, TreParameter> parameters = new HashMap<>();
+
+    private static final int DECIMAL_BASE = 10;
 
     int getIntValue(final String key) {
-        return Integer.parseInt(getFieldValue(key));
+        TreParameter parameter = parameters.get(key);
+        if ("UINT".equals(parameter.mFieldType)) {
+            int res = 0;
+            for (int i = 0; i < parameter.mFieldValue.length(); ++i) {
+                res = (res << Byte.SIZE) + Byte.toUnsignedInt(parameter.mFieldValue.getBytes(StandardCharsets.US_ASCII)[i]);
+            }
+            return res;
+        } else {
+            return Integer.parseInt(parameter.mFieldValue, DECIMAL_BASE);
+        }
     }
 
     String getFieldValue(final String key) {
-        return parameters.get(key);
+        return parameters.get(key).mFieldValue;
     }
 
-    void addParameter(final String fieldKey, final String fieldValue) {
-        parameters.put(fieldKey, fieldValue);
+    void addParameter(final String fieldKey, final String fieldValue, final String fieldType) {
+        parameters.put(fieldKey, new TreParameter(fieldValue, fieldType));
+    }
+
+    private static final class TreParameter {
+
+        private final String mFieldValue;
+        private final String mFieldType;
+
+        private TreParameter(final String fieldValue, final String fieldType) {
+            mFieldValue = fieldValue;
+            mFieldType = fieldType;
+        }
     }
 }

--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -32,7 +32,7 @@
 
 <!-- This file should validate against nitf_spec.xsd -->
 
-<tres>
+<tres xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/codice/imaging-nitf/master/core/src/main/xsd/nitf_spec.xsd">
 
     <tre name="ACCPOB" minlength="17" maxlength="99985" location="image">
         <field name="NUM_ACPO" length="2" type="integer" minval="1" maxval="99"/>
@@ -322,9 +322,9 @@
     <!-- STDI-0002 Appendix E (ASDE 2.1/CN1), Table E-12 -->
     <tre name="EXPLTB" length="101" location="image">
         <field name="ANGLE_TO_NORTH" length="7" type="real" minval="0.0" maxval="359.999"/>
-        <field name="ANGLE_TO_NORTH_ACCY" length="6" type="real" min="0.0" maxval="44.999"/>
-        <field name="SQUINT_ANGLE" length="7" type="real" min="-60.0" maxval="85.0"/>
-        <field name="SQUINT_ANGLE_ACCY" length="6" type="real" min="0.0" maxval="44.999"/>
+        <field name="ANGLE_TO_NORTH_ACCY" length="6" type="real" minval="0.0" maxval="44.999"/>
+        <field name="SQUINT_ANGLE" length="7" type="real" minval="-60.0" maxval="85.0"/>
+        <field name="SQUINT_ANGLE_ACCY" length="6" type="real" minval="0.0" maxval="44.999"/>
         <field name="MODE" length="3" type="string"/>
         <field length="16" fixed_value="                "/>
         <field name="GRAZE_ANG" length="5" type="real" unit="degrees" minval="0.0" maxval="90.00"/>
@@ -517,6 +517,28 @@
         <field name="TOTAL_TILES_ROWS" length="5" type="integer" minval="1" maxval="99999"/>
     </tre>
 
+    <!-- MIE4NITF Version 1.1, Section 5.9.4.7 Motion Imaging Segment TRE (MTIMSA) and Table 17 -->
+    <tre name="MTIMSA" minlength="150" maxlength="99985" location="image">
+        <field name="IMAGE_SEG_INDEX" length="3" type="integer" minval="1" maxval="999"/>
+        <field name="GEOCOORDS_STATIC" length="2" type="string"/>
+        <field name="LAYER_ID" length="36" type="string"/>
+        <field name="CAMERA_SET_INDEX" length="3" type="integer" minval="0" maxval="999"/>
+        <field name="CAMERA_ID" length="36" type="string"/>
+        <field name="TIME_INTERVAL_INDEX" length="6" type="integer" minval="0" maxval="999999"/>
+        <field name="TEMP_BLOCK_INDEX" length="3" type="integer" minval="0" maxval="999"/>
+        <!-- TODO: make this type="UE/13" -->
+        <field name="NOMINAL_FRAME_RATE" length="13" type="real"/>
+        <field name="REFERENCE_FRAME_NUM" length="9" type="string"/>
+        <field name="BASE_TIMESTAMP" length="24" type="string"/>
+        <field name="DT_MULTIPLIER" length="8" type="UINT"/>
+        <field name="DT_SIZE" length="1" type="UINT" minval="1" maxval="8"/>
+        <field name="NUMBER_FRAMES" length="4" type="UINT"/>
+        <field name="NUMBER_DT" length="4" type="UINT"/>
+        <loop counter="NUMBER_DT" md_prefix="DT%d" name="DELTA_TIME">
+            <field name="DT" length_var="DT_SIZE" type="UINT"/>
+        </loop>
+    </tre>
+
     <!-- STDI-0002 Appendix E (ASDE 2.1/CN1), Section 3.10 and Table E-19 -->
     <tre name="MTIRPB" minlength="119" maxlength="42035">
         <field name="MTI_DP" length="2" type="string"/>
@@ -535,43 +557,43 @@
         <field name="NO_VALID_TARGETS" length="3" minval="1" maxval="999" type="integer"/>
         <loop counter="NO_VALID_TARGETS" md_prefix="TGT_%03d_" name="TARGETS">
             <field name="TGT_LOC" length="23" type="string"/>
-            <field name="TGT_LOC_ACCY" length="6" min_val="0" max_val="999.99" type="real"/>
-            <field name="TGT_VEL_R" length="4" min_val="-200" max_val="200" type="string"/>
-            <field name="TGT_SPEED" length="3" min_val="0" max_val="200" type="string"/>
-            <field name="TGT_HEADING" length="3" min_val="0" maxval="359" type="string"/>
-            <field name="TGT_AMPLITUDE" length="2" min_val="0" maxval="15" type="string"/>
+            <field name="TGT_LOC_ACCY" length="6" minval="0" maxval="999.99" type="real"/>
+            <field name="TGT_VEL_R" length="4" minval="-200" maxval="200" type="string"/>
+            <field name="TGT_SPEED" length="3" minval="0" maxval="200" type="string"/>
+            <field name="TGT_HEADING" length="3" minval="0" maxval="359" type="string"/>
+            <field name="TGT_AMPLITUDE" length="2" minval="0" maxval="15" type="string"/>
             <field name="TGT_CAT" length="1" type="string"/>
         </loop>
     </tre>
 
     <!-- STDI-0002 Appendix E (ASDE 2.1/CN1), Table E-21 -->
-    <tre name="PATCHB" size="121" location="image">
+    <tre name="PATCHB" length="121" location="image">
         <field name="PAT_NO" length="4" type="integer" minval="1" maxval="999"/>
         <!-- LAST_PAT_LEVEL is a string because it is <R>, so it may contain only a space -->
         <field name="LAST_PAT_FLAG" length="1" type="integer" minval="0" maxval="1"/>
         <field name="LNSTRT" length="7" type="integer" minval="1" maxval="9999999"/>
         <field name="LNSTOP" length="7" type="integer" minval="20" maxval="9999999"/>
-        <field name="AZL" length="5" type="integer" units="lines" minval="20" maxval="99999"/>
+        <field name="AZL" length="5" type="integer" minval="20" maxval="99999"/>
         <!-- NVL is a string because it is <R> -->
-        <field name="NVL" length="5" type="string" units="lines"/>
+        <field name="NVL" length="5" type="string"/>
         <!-- FVL is a string because it is <R> -->
         <field name="FVL" length="3" type="string" minval="1" maxval="681"/>
-        <field name="NPIXEL" length="5" type="integer" units="pixels" minval="1" maxval="99999"/>
-        <field name="FVPIX" length="5" type="integer" units="pixels" minval="1" maxval="99999"/>
+        <field name="NPIXEL" length="5" type="integer" minval="1" maxval="99999"/>
+        <field name="FVPIX" length="5" type="integer" minval="1" maxval="99999"/>
         <!-- FRAME is a string because it is <R> -->
         <field name="FRAME" length="3" type="string" minval="1" maxval="512"/>
-        <field name="UTC" length="8" type="real" units="seconds" minval="0.0" maxval="86399.99"/>
-        <field name="SHEAD" length="7" type="real" units="degrees" minval="0.0" maxval="359.999"/>
+        <field name="UTC" length="8" type="real" minval="0.0" maxval="86399.99"/>
+        <field name="SHEAD" length="7" type="real" minval="0.0" maxval="359.999"/>
         <!-- GRAVITY is a string because it is <R> -->
-        <field name="GRAVITY" length="7" type="string" units="feet/sec^2"/>
-        <field name="INS_V_NC" length="5" type="integer" units="feet/sec" minval="-9999" maxval="9999"/>
-        <field name="INS_V_EC" length="5" type="integer" units="feet/sec" minval="-9999" maxval="9999"/>
-        <field name="INS_V_DC" length="5" type="integer" units="feet/sec" minval="-9999" maxval="9999"/>
+        <field name="GRAVITY" length="7" type="string"/>
+        <field name="INS_V_NC" length="5" type="integer" minval="-9999" maxval="9999"/>
+        <field name="INS_V_EC" length="5" type="integer" minval="-9999" maxval="9999"/>
+        <field name="INS_V_DC" length="5" type="integer" minval="-9999" maxval="9999"/>
         <!-- OFFLAT and OFFLONG are string because they are <R> -->
-        <field name="OFFLAT" length="8" type="string" units="seconds"/>
-        <field name="OFFLONG" length="8" type="string" units="seconds"/>
-        <field name="TRACK" length="3" type="integer" units="degrees" minval="0" maxval="359"/>
-        <field name="GSWEEP" length="6" type="real" units="degrees" minval="0.0" maxval="120.0"/>
+        <field name="OFFLAT" length="8" type="string"/>
+        <field name="OFFLONG" length="8" type="string"/>
+        <field name="TRACK" length="3" type="integer" minval="0" maxval="359"/>
+        <field name="GSWEEP" length="6" type="real" minval="0.0" maxval="120.0"/>
         <!-- SHEAR is a string because it is <R> -->
         <field name="SHEAR" length="8" type="string"/>
         <!-- BATCH_NO is a string because it is <R> -->

--- a/core/src/main/xsd/nitf_spec.xsd
+++ b/core/src/main/xsd/nitf_spec.xsd
@@ -125,6 +125,7 @@
                     <xs:enumeration value="string"/>
                     <xs:enumeration value="integer"/>
                     <xs:enumeration value="real"/>
+                    <xs:enumeration value="UINT"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/ENGRDA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/ENGRDA_Test.java
@@ -95,20 +95,20 @@ public class ENGRDA_Test {
     public void BuildENGRDA() throws NitfFormatException {
         Tre engrda = TreFactory.getDefault("ENGRDA", TreSource.UserDefinedHeaderData);
         assertNotNull(engrda);
-        engrda.add(new TreEntry("RESRC", "GEOMOS"));
-        engrda.add(new TreEntry("RECNT", "1"));
+        engrda.add(new TreEntry("RESRC", "GEOMOS", "string"));
+        engrda.add(new TreEntry("RECNT", "1", "integer"));
         TreEntry records = new TreEntry("RECORDS");
         engrda.add(records);
         TreGroup record0 = new TreGroupImpl();
-        record0.add(new TreEntry("ENGLN", "11"));
-        record0.add(new TreEntry("ENGLBL", "TEMPERATURE"));
-        record0.add(new TreEntry("ENGMTXC", "3"));
-        record0.add(new TreEntry("ENGMTXR", "1"));
-        record0.add(new TreEntry("ENGTYP", "A"));
-        record0.add(new TreEntry("ENGDTS", "1"));
-        record0.add(new TreEntry("ENGDATU", "NA"));
-        record0.add(new TreEntry("ENGDATC", "3"));
-        record0.add(new TreEntry("ENGDATA", "374"));
+        record0.add(new TreEntry("ENGLN", "11", "integer"));
+        record0.add(new TreEntry("ENGLBL", "TEMPERATURE", "string"));
+        record0.add(new TreEntry("ENGMTXC", "3", "integer"));
+        record0.add(new TreEntry("ENGMTXR", "1", "integer"));
+        record0.add(new TreEntry("ENGTYP", "A", "string"));
+        record0.add(new TreEntry("ENGDTS", "1", "integer"));
+        record0.add(new TreEntry("ENGDATU", "NA", "string"));
+        record0.add(new TreEntry("ENGDATC", "3", "integer"));
+        record0.add(new TreEntry("ENGDATA", "374", "string"));
         records.addGroup(record0);
 
         TreParser parser = new TreParser();

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/MTIMSA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/MTIMSA_Test.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import static javax.xml.bind.DatatypeConverter.parseHexBinary;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+/**
+ * Tests for parsing MTIMSA.
+ *
+ * This is defined in NGA.STND.0044 1.1, as part of MIE4NITF. See Section 5.9.4.7 and Table 17.
+ */
+public class MTIMSA_Test extends SharedTreTest {
+
+    public MTIMSA_Test() {
+    }
+
+    @Test
+    public void SimpleParse() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write("MTIMSA0016000199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e840000030045.0000000E+0100000000620160716215756.012345678".getBytes(StandardCharsets.US_ASCII));
+        baos.write(parseHexBinary("0000000001312D00"));
+        baos.write(parseHexBinary("01"));
+        baos.write(parseHexBinary("01020304"));
+        baos.write(parseHexBinary("00000001"));
+        baos.write(parseHexBinary("4e"));
+        Tre mtimsa = doParseAndCheckResults(baos);
+        assertEquals(1, mtimsa.getIntValue("DT_SIZE"));
+        assertEquals(16909060, mtimsa.getIntValue("NUMBER_FRAMES"));
+        assertEquals(1, mtimsa.getIntValue("NUMBER_DT"));
+        TreGroup deltaTimes = mtimsa.getEntry("DELTA_TIME").getGroups().get(0);
+        assertEquals(1, deltaTimes.getEntries().size());
+        assertEquals(78, deltaTimes.getIntValue("DT"));
+    }
+
+    @Test
+    public void Uint64Parse() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write("MTIMSA0016700199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e840000030045.0000000E+0100000000620160716215756.012345678".getBytes(StandardCharsets.US_ASCII));
+        baos.write(parseHexBinary("0000000001312D00"));
+        baos.write(parseHexBinary("08"));
+        baos.write(parseHexBinary("01020304"));
+        baos.write(parseHexBinary("00000001"));
+        baos.write(parseHexBinary("7ffffffffffffffe"));
+        Tre mtimsa = doParseAndCheckResults(baos);
+        assertEquals(8, mtimsa.getLongIntegerValue("DT_SIZE"));
+        assertEquals(16909060, mtimsa.getLongIntegerValue("NUMBER_FRAMES"));
+        assertEquals(1, mtimsa.getLongIntegerValue("NUMBER_DT"));
+        TreGroup deltaTimes = mtimsa.getEntry("DELTA_TIME").getGroups().get(0);
+        assertEquals(1, deltaTimes.getEntries().size());
+        assertEquals(0x7FFFFFFFFFFFFFFEL, deltaTimes.getLongIntegerValue("DT"));
+    }
+
+    private Tre doParseAndCheckResults(ByteArrayOutputStream baos) throws NitfFormatException {
+        Tre mtimsa = parseTRE(baos.toByteArray(), baos.toByteArray().length, "MTIMSA");
+        assertEquals(15, mtimsa.getEntries().size());
+        assertEquals("001", mtimsa.getFieldValue("IMAGE_SEG_INDEX"));
+        assertEquals("99", mtimsa.getFieldValue("GEOCOORDS_STATIC"));
+        assertEquals("fa238862-73ed-41fc-8d52-bfc7a954428c", mtimsa.getFieldValue("LAYER_ID"));
+        assertEquals("002", mtimsa.getFieldValue("CAMERA_SET_INDEX"));
+        assertEquals("95cb5511-7350-479b-9c8a-f028aba01e84", mtimsa.getFieldValue("CAMERA_ID"));
+        assertEquals("000003", mtimsa.getFieldValue("TIME_INTERVAL_INDEX"));
+        assertEquals("004", mtimsa.getFieldValue("TEMP_BLOCK_INDEX"));
+        assertEquals("5.0000000E+01", mtimsa.getFieldValue("NOMINAL_FRAME_RATE"));
+        assertEquals(50.0, mtimsa.getDoubleValue("NOMINAL_FRAME_RATE"), 0.000000001);
+        assertEquals("000000006", mtimsa.getFieldValue("REFERENCE_FRAME_NUM"));
+        assertEquals("20160716215756.012345678", mtimsa.getFieldValue("BASE_TIMESTAMP"));
+        assertEquals(20000000, mtimsa.getIntValue("DT_MULTIPLIER"));
+        return mtimsa;
+    }
+}

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/MTIMSA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/MTIMSA_Test.java
@@ -59,12 +59,12 @@ public class MTIMSA_Test extends SharedTreTest {
         baos.write(parseHexBinary("00000001"));
         baos.write(parseHexBinary("7ffffffffffffffe"));
         Tre mtimsa = doParseAndCheckResults(baos);
-        assertEquals(8, mtimsa.getLongIntegerValue("DT_SIZE"));
-        assertEquals(16909060, mtimsa.getLongIntegerValue("NUMBER_FRAMES"));
-        assertEquals(1, mtimsa.getLongIntegerValue("NUMBER_DT"));
+        assertEquals(8, mtimsa.getLongValue("DT_SIZE"));
+        assertEquals(16909060, mtimsa.getLongValue("NUMBER_FRAMES"));
+        assertEquals(1, mtimsa.getLongValue("NUMBER_DT"));
         TreGroup deltaTimes = mtimsa.getEntry("DELTA_TIME").getGroups().get(0);
         assertEquals(1, deltaTimes.getEntries().size());
-        assertEquals(0x7FFFFFFFFFFFFFFEL, deltaTimes.getLongIntegerValue("DT"));
+        assertEquals(0x7FFFFFFFFFFFFFFEL, deltaTimes.getLongValue("DT"));
     }
 
     private Tre doParseAndCheckResults(ByteArrayOutputStream baos) throws NitfFormatException {

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/SharedTreTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/SharedTreTest.java
@@ -29,7 +29,12 @@ import static org.junit.Assert.assertNotNull;
 class SharedTreTest {
     
     protected Tre parseTRE(String testData, int expectedLength, String treTag) throws NitfFormatException {
-        InputStream inputStream = new ByteArrayInputStream(testData.getBytes());
+        byte bytes[] = testData.getBytes();
+        return parseTRE(bytes, expectedLength, treTag);
+    }
+
+    protected Tre parseTRE(byte[] bytes, int expectedLength, String treTag) throws NitfFormatException {
+        InputStream inputStream = new ByteArrayInputStream(bytes);
         BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
         NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
         TreCollectionParser parser = new TreCollectionParser();

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTest.java
@@ -22,7 +22,7 @@ public class TreTest {
 
     @Test
     public void testTreEntryAccessors1() {
-        TreEntry entry = new TreEntry("oldName", null);
+        TreEntry entry = new TreEntry("oldName", null, "string");
         assertNotNull(entry);
 
         entry.setName("DANAME");
@@ -34,7 +34,7 @@ public class TreTest {
 
     @Test
     public void testTreEntryAccessors2() {
-        TreEntry entry = new TreEntry("ANAME", null);
+        TreEntry entry = new TreEntry("ANAME", null, null);
         assertNotNull(entry);
 
         entry.initGroups();

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTortureTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTortureTest.java
@@ -501,10 +501,10 @@ public class TreTortureTest {
     public void parseTST10A() throws NitfFormatException {
         BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary("5453543130413030303333" + "fff02367" + "ff01020304" + "ff0102030405" + "ff010203040506" + "7f01020304050607")));
         Tre tre = parseTST10A(bufferedStream);
-        assertEquals(0xfff02367L, tre.getLongIntegerValue("UINT4"));
-        assertEquals(0xff01020304L, tre.getLongIntegerValue("UINT5"));
-        assertEquals(0xff0102030405L, tre.getLongIntegerValue("UINT6"));
-        assertEquals(0xff010203040506L, tre.getLongIntegerValue("UINT7"));
+        assertEquals(0xfff02367L, tre.getLongValue("UINT4"));
+        assertEquals(0xff01020304L, tre.getLongValue("UINT5"));
+        assertEquals(0xff0102030405L, tre.getLongValue("UINT6"));
+        assertEquals(0xff010203040506L, tre.getLongValue("UINT7"));
         assertEquals(new BigInteger("9151598129769154055"), tre.getBigIntegerValue("UINT8"));
     }
 
@@ -523,10 +523,10 @@ public class TreTortureTest {
     public void parseTST10A_0xff() throws NitfFormatException {
         BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary("5453543130413030303333" + "ffffffff" + "ffffffffff" + "ffffffffffff" + "ffffffffffffff" + "ffffffffffffffff")));
         Tre tre = parseTST10A(bufferedStream);
-        assertEquals(4294967295L, tre.getLongIntegerValue("UINT4"));
-        assertEquals(1099511627775L, tre.getLongIntegerValue("UINT5"));
-        assertEquals(281474976710655L, tre.getLongIntegerValue("UINT6"));
-        assertEquals(72057594037927935L, tre.getLongIntegerValue("UINT7"));
+        assertEquals(4294967295L, tre.getLongValue("UINT4"));
+        assertEquals(1099511627775L, tre.getLongValue("UINT5"));
+        assertEquals(281474976710655L, tre.getLongValue("UINT6"));
+        assertEquals(72057594037927935L, tre.getLongValue("UINT7"));
         assertEquals(new BigInteger("18446744073709551615"), tre.getBigIntegerValue("UINT8"));
     }
 

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTortureTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/TreTortureTest.java
@@ -17,7 +17,9 @@ package org.codice.imaging.nitf.core.tre;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.StringReader;
+import java.math.BigInteger;
 import java.util.List;
+import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
@@ -76,6 +78,22 @@ public class TreTortureTest {
             + "             <field name=\"VALUE\" type=\"integer\" length=\"4\"/>"
             + "         </loop>"
             + "     </tre>"
+            + "     <tre name=\"TST07A\">"
+            + "         <field name=\"UINT\" type=\"UINT\" length=\"1\"/>"
+            + "     </tre>"
+            + "     <tre name=\"TST08A\">"
+            + "         <field name=\"UINT\" type=\"UINT\" length=\"2\"/>"
+            + "     </tre>"
+            + "     <tre name=\"TST09A\">"
+            + "         <field name=\"UINT\" type=\"UINT\" length=\"3\"/>"
+            + "     </tre>"
+            + "     <tre name=\"TST10A\">"
+            + "         <field name=\"UINT4\" type=\"UINT\" length=\"4\"/>"
+            + "         <field name=\"UINT5\" type=\"UINT\" length=\"5\"/>"
+            + "         <field name=\"UINT6\" type=\"UINT\" length=\"6\"/>"
+            + "         <field name=\"UINT7\" type=\"UINT\" length=\"7\"/>"
+            + "         <field name=\"UINT8\" type=\"UINT\" length=\"8\"/>"
+            + "     </tre>"
             + "</tres>";
 
     private final Source sourceTREs = new StreamSource(new StringReader(xmlTREs));
@@ -86,7 +104,7 @@ public class TreTortureTest {
     @Test
     public void checkMissingType() throws NitfFormatException {
         Tre tst01a = TreFactory.getDefault("TST01A", TreSource.UserDefinedHeaderData);
-        tst01a.add(new TreEntry("INFO", "Some information"));
+        tst01a.add(new TreEntry("INFO", "Some information", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREwithoutType);
         exception.expect(NitfFormatException.class);
@@ -105,7 +123,7 @@ public class TreTortureTest {
     @Test
     public void checkBasic() throws NitfFormatException {
         Tre tst01a = TreFactory.getDefault("TST01A", TreSource.UserDefinedHeaderData);
-        tst01a.add(new TreEntry("INFO", "Some information"));
+        tst01a.add(new TreEntry("INFO", "Some information", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst01a);
@@ -117,7 +135,7 @@ public class TreTortureTest {
     @Test
     public void checkTST01A_TooLongString() throws NitfFormatException {
         Tre tst01a = TreFactory.getDefault("TST01A", TreSource.UserDefinedHeaderData);
-        tst01a.add(new TreEntry("INFO", "Some more information"));
+        tst01a.add(new TreEntry("INFO", "Some more information", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -128,7 +146,7 @@ public class TreTortureTest {
     @Test
     public void checkTST01A_NullString() throws NitfFormatException {
         Tre tst01a = TreFactory.getDefault("TST01A", TreSource.UserDefinedHeaderData);
-        tst01a.add(new TreEntry("INFO", null));
+        tst01a.add(new TreEntry("INFO", null, "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -139,7 +157,7 @@ public class TreTortureTest {
     @Test
     public void checkTST02A_Integer() throws NitfFormatException {
         Tre tst02a = TreFactory.getDefault("TST02A", TreSource.UserDefinedHeaderData);
-        tst02a.add(new TreEntry("NUM_INT", "2"));
+        tst02a.add(new TreEntry("NUM_INT", "2", "integer"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst02a);
@@ -151,7 +169,7 @@ public class TreTortureTest {
     @Test
     public void checkTST02A_MinValue() throws NitfFormatException {
         Tre tst02a = TreFactory.getDefault("TST02A", TreSource.UserDefinedHeaderData);
-        tst02a.add(new TreEntry("NUM_INT", "1"));
+        tst02a.add(new TreEntry("NUM_INT", "1", "integer"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -162,7 +180,7 @@ public class TreTortureTest {
     @Test
     public void checkTST02A_MaxValue() throws NitfFormatException {
         Tre tst02a = TreFactory.getDefault("TST02A", TreSource.UserDefinedHeaderData);
-        tst02a.add(new TreEntry("NUM_INT", "105"));
+        tst02a.add(new TreEntry("NUM_INT", "105", "integer"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -173,7 +191,7 @@ public class TreTortureTest {
     @Test
     public void checkTST02A_BadFormat() throws NitfFormatException {
         Tre tst02a = TreFactory.getDefault("TST02A", TreSource.UserDefinedHeaderData);
-        tst02a.add(new TreEntry("NUM_INT", "z1"));
+        tst02a.add(new TreEntry("NUM_INT", "z1", "integer"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -184,8 +202,8 @@ public class TreTortureTest {
     @Test
     public void checkTST03A_Valid() throws NitfFormatException {
         Tre tst03a = TreFactory.getDefault("TST03A", TreSource.UserDefinedHeaderData);
-        tst03a.add(new TreEntry("INFO_LEN", String.valueOf("Some more information.".length())));
-        tst03a.add(new TreEntry("INFO", "Some more information."));
+        tst03a.add(new TreEntry("INFO_LEN", String.valueOf("Some more information.".length()), "integer"));
+        tst03a.add(new TreEntry("INFO", "Some more information.", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst03a);
@@ -197,8 +215,8 @@ public class TreTortureTest {
     @Test
     public void checkTST03A_VarLengthMismatch() throws NitfFormatException {
         Tre tst03a = TreFactory.getDefault("TST03A", TreSource.UserDefinedHeaderData);
-        tst03a.add(new TreEntry("INFO_LEN", "21"));
-        tst03a.add(new TreEntry("INFO", "Some more information."));
+        tst03a.add(new TreEntry("INFO_LEN", "21", "integer"));
+        tst03a.add(new TreEntry("INFO", "Some more information.", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -209,7 +227,7 @@ public class TreTortureTest {
     @Test
     public void checkTST04A_Valid() throws NitfFormatException {
         Tre tst04a = TreFactory.getDefault("TST04A", TreSource.UserDefinedHeaderData);
-        tst04a.add(new TreEntry("SCALE", "2.3"));
+        tst04a.add(new TreEntry("SCALE", "2.3", "real"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst04a);
@@ -221,7 +239,7 @@ public class TreTortureTest {
     @Test
     public void checkTST04A_TooMuchPrecision() throws NitfFormatException {
         Tre tst04a = TreFactory.getDefault("TST04A", TreSource.UserDefinedHeaderData);
-        tst04a.add(new TreEntry("SCALE", "2.3012343"));
+        tst04a.add(new TreEntry("SCALE", "2.3012343", "real"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst04a);
@@ -233,7 +251,7 @@ public class TreTortureTest {
     @Test
     public void checkTST04A_BadFormat() throws NitfFormatException {
         Tre tst04a = TreFactory.getDefault("TST04A", TreSource.UserDefinedHeaderData);
-        tst04a.add(new TreEntry("SCALE", "z1"));
+        tst04a.add(new TreEntry("SCALE", "z1", "real"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -244,7 +262,7 @@ public class TreTortureTest {
     @Test
     public void checkTST04A_MinValue() throws NitfFormatException {
         Tre tst04a = TreFactory.getDefault("TST04A", TreSource.UserDefinedHeaderData);
-        tst04a.add(new TreEntry("SCALE", "0.24999"));
+        tst04a.add(new TreEntry("SCALE", "0.24999", "real"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -255,7 +273,7 @@ public class TreTortureTest {
     @Test
     public void checkTST04A_MaxValue() throws NitfFormatException {
         Tre tst04a = TreFactory.getDefault("TST04A", TreSource.UserDefinedHeaderData);
-        tst04a.add(new TreEntry("SCALE", "4.0001"));
+        tst04a.add(new TreEntry("SCALE", "4.0001", "real"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         exception.expect(NitfFormatException.class);
@@ -266,8 +284,8 @@ public class TreTortureTest {
     @Test
     public void checkTST05A_ValidNoFlag() throws NitfFormatException {
         Tre tst05a = TreFactory.getDefault("TST05A", TreSource.UserDefinedHeaderData);
-        tst05a.add(new TreEntry("FLAG", "N"));
-        tst05a.add(new TreEntry("TEXT", "HELLO WORLD"));
+        tst05a.add(new TreEntry("FLAG", "N", "string"));
+        tst05a.add(new TreEntry("TEXT", "HELLO WORLD", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst05a);
@@ -279,9 +297,9 @@ public class TreTortureTest {
     @Test
     public void checkTST05A_ValidWithFlag() throws NitfFormatException {
         Tre tst05a = TreFactory.getDefault("TST05A", TreSource.UserDefinedHeaderData);
-        tst05a.add(new TreEntry("FLAG", "Y"));
-        tst05a.add(new TreEntry("NUMB", "3"));
-        tst05a.add(new TreEntry("TEXT", "HELLO WORLD"));
+        tst05a.add(new TreEntry("FLAG", "Y", "string"));
+        tst05a.add(new TreEntry("NUMB", "3", "integer"));
+        tst05a.add(new TreEntry("TEXT", "HELLO WORLD", "string"));
         TreParser parser = new TreParser();
         parser.registerAdditionalTREdescriptor(sourceTREs);
         byte[] serialisedTre = parser.serializeTRE(tst05a);
@@ -348,8 +366,8 @@ public class TreTortureTest {
         tst06a.add(coefficients);
         for (int i = 0; i < 5; i++) {
             TreGroup coefficient = new TreGroupImpl();
-            coefficient.add(new TreEntry("CONCEPT", String.format("Key %d", i + 1)));
-            coefficient.add(new TreEntry("VALUE", String.valueOf(i * 7 + 1)));
+            coefficient.add(new TreEntry("CONCEPT", String.format("Key %d", i + 1), "string"));
+            coefficient.add(new TreEntry("VALUE", String.valueOf(i * 7 + 1), "integer"));
             coefficients.addGroup(coefficient);
         }
 
@@ -391,5 +409,162 @@ public class TreTortureTest {
         assertEquals("0029", coef5.getFieldValue("VALUE"));
     }
 
+    // "TST07A00001"
+    static final String TST07A_ONE = "5453543037413030303031";
+    // "TST08A00002"
+    static final String TST08A_TWO = "5453543038413030303032";
+    // "TST09A00003"
+    static final String TST09A_THREE = "5453543039413030303033";
+
+    @Test
+    public void parseTST07A_0x00() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST07A_ONE + "00")));
+        Tre tst07a = parseTST07AsingleByte(bufferedStream);
+
+        TreEntry uint = tst07a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(0x00, uint.getFieldValue().getBytes()[0]);
+        assertEquals(0, tst07a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST07A_0x01() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST07A_ONE + "01")));
+        Tre tst07a = parseTST07AsingleByte(bufferedStream);
+
+        TreEntry uint = tst07a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(1, tst07a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST07A_0x7f() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST07A_ONE + "7f")));
+        Tre tst07a = parseTST07AsingleByte(bufferedStream);
+
+        TreEntry uint = tst07a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(127, tst07a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST07A_0xff() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST07A_ONE + "ff")));
+        Tre tst07a = parseTST07AsingleByte(bufferedStream);
+
+        TreEntry uint = tst07a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(255, tst07a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST08A_0xffff() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST08A_TWO + "ffff")));
+        Tre tst08a = parseTST_UINT(bufferedStream, 2);
+
+        TreEntry uint = tst08a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(65535, tst08a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST09A_0x01ffff() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST09A_THREE + "01ffff")));
+        Tre tst09a = parseTST_UINT(bufferedStream, 3);
+
+        TreEntry uint = tst09a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(65536 + 65535, tst09a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST09A_0xffffff() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST09A_THREE + "ffffff")));
+        Tre tst09a = parseTST_UINT(bufferedStream, 3);
+
+        TreEntry uint = tst09a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(16777215, tst09a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST09A_0xf02367() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary(TST09A_THREE + "f02367")));
+        Tre tst09a = parseTST_UINT(bufferedStream, 3);
+
+        TreEntry uint = tst09a.getEntries().get(0);
+        assertNotNull(uint);
+        assertEquals(15737703, tst09a.getIntValue("UINT"));
+    }
+
+    @Test
+    public void parseTST10A() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary("5453543130413030303333" + "fff02367" + "ff01020304" + "ff0102030405" + "ff010203040506" + "7f01020304050607")));
+        Tre tre = parseTST10A(bufferedStream);
+        assertEquals(0xfff02367L, tre.getLongIntegerValue("UINT4"));
+        assertEquals(0xff01020304L, tre.getLongIntegerValue("UINT5"));
+        assertEquals(0xff0102030405L, tre.getLongIntegerValue("UINT6"));
+        assertEquals(0xff010203040506L, tre.getLongIntegerValue("UINT7"));
+        assertEquals(new BigInteger("9151598129769154055"), tre.getBigIntegerValue("UINT8"));
+    }
+
+    @Test
+    public void parseTST10A_0x00() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary("5453543130413030303333" + "00000000" + "0000000000" + "000000000000" + "00000000000000" + "0000000000000000")));
+        Tre tre = parseTST10A(bufferedStream);
+        assertEquals(0L, tre.getIntValue("UINT4"));
+        assertEquals(0L, tre.getIntValue("UINT5"));
+        assertEquals(0L, tre.getIntValue("UINT6"));
+        assertEquals(0L, tre.getIntValue("UINT7"));
+        assertEquals(0L, tre.getIntValue("UINT8"));
+    }
+
+    @Test
+    public void parseTST10A_0xff() throws NitfFormatException {
+        BufferedInputStream bufferedStream = new BufferedInputStream(new ByteArrayInputStream(parseHexBinary("5453543130413030303333" + "ffffffff" + "ffffffffff" + "ffffffffffff" + "ffffffffffffff" + "ffffffffffffffff")));
+        Tre tre = parseTST10A(bufferedStream);
+        assertEquals(4294967295L, tre.getLongIntegerValue("UINT4"));
+        assertEquals(1099511627775L, tre.getLongIntegerValue("UINT5"));
+        assertEquals(281474976710655L, tre.getLongIntegerValue("UINT6"));
+        assertEquals(72057594037927935L, tre.getLongIntegerValue("UINT7"));
+        assertEquals(new BigInteger("18446744073709551615"), tre.getBigIntegerValue("UINT8"));
+    }
+
+    private Tre parseTST10A(BufferedInputStream bufferedStream) throws NitfFormatException {
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        parser.registerAdditionalTREdescriptor(sourceTREs);
+        TreCollection parseResult = parser.parse(nitfReader, 11 + 33, TreSource.UserDefinedHeaderData);
+        assertNotNull(parseResult);
+        assertNotNull(parseResult.getTREs());
+        assertEquals(1, parseResult.getTREs().size());
+        Tre tre = parseResult.getTREs().get(0);
+        assertNotNull(tre);
+        assertNotNull(tre.getEntries());
+        assertEquals(5, tre.getEntries().size());
+        return tre;
+    }
+
+    private Tre parseTST07AsingleByte(BufferedInputStream bufferedStream) throws NitfFormatException {
+        return parseTST_UINT(bufferedStream, 1);
+    }
+
+    private Tre parseTST_UINT(BufferedInputStream bufferedStream, int length) throws NitfFormatException {
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
+        TreCollectionParser parser = new TreCollectionParser();
+        parser.registerAdditionalTREdescriptor(sourceTREs);
+        TreCollection parseResult = parser.parse(nitfReader, 11 + length, TreSource.UserDefinedHeaderData);
+        assertNotNull(parseResult);
+        assertNotNull(parseResult.getTREs());
+        assertEquals(1, parseResult.getTREs().size());
+        Tre tre = parseResult.getTREs().get(0);
+        assertNotNull(tre);
+        assertNotNull(tre.getEntries());
+        assertEquals(1, tre.getEntries().size());
+        return tre;
+    }
+
+
     // TODO: check data types per MIL-STD-2500C 5.1.7a
+
 }

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/FlatTreWrapper.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/FlatTreWrapper.java
@@ -58,9 +58,10 @@ public abstract class FlatTreWrapper extends TreWrapper {
      *
      * @param fieldName the field name for the TRE.
      * @param value the value to set.
+     * @param fieldType the data type of the value to be written
      * @throws NitfFormatException if there is a parsing error.
      */
-    protected final void addOrUpdateEntry(final String fieldName, final String value) throws NitfFormatException {
+    protected final void addOrUpdateEntry(final String fieldName, final String value, final String fieldType) throws NitfFormatException {
         for (TreEntry entry : mTre.getEntries()) {
             if (entry.getName().equals(fieldName)) {
                 mTre.getEntry(fieldName).setFieldValue(value);
@@ -68,7 +69,7 @@ public abstract class FlatTreWrapper extends TreWrapper {
             }
         }
         // Didn't find it, just add.
-        mTre.add(new TreEntry(fieldName, value));
+        mTre.add(new TreEntry(fieldName, value, fieldType));
     }
 
     /**
@@ -87,6 +88,6 @@ public abstract class FlatTreWrapper extends TreWrapper {
         if (date != null) {
             value = date.format(CENTURY_DATE_FORMATTER);
         }
-        addOrUpdateEntry(fieldName, value);
+        addOrUpdateEntry(fieldName, value, "string");
     }
 }

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/MTIMSA.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/MTIMSA.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.trewrap;
+
+import java.math.BigInteger;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.codice.imaging.nitf.core.tre.TreGroup;
+
+/**
+ * Wrapper for the Motion Imagery Segment (MTIMSA) TRE.
+ */
+public class MTIMSA extends TreWrapper {
+
+    private static final String TAG_NAME = "MTIMSA";
+    private static final BigInteger NANOSECONDS_IN_ONE_SECOND = BigInteger.valueOf(1000000000);
+
+    /**
+     * Create a MTIMSA TRE wrapper from an existing TRE.
+     *
+     * @param tre the TRE to wrap. Must match the MTIMSA tag.
+     * @throws NitfFormatException if there is a parsing issue.
+     */
+    public MTIMSA(final Tre tre) throws NitfFormatException {
+        super(tre, TAG_NAME);
+    }
+
+    /**
+     * Get the image segment index.
+     *
+     * From MIE4NITF Version 1.1: IMAGE_SEG_INDEX – The index of this NITF Image
+     * Segment within the NITF File. This field is provided as protection
+     * against a legacy tool that modifies the NITF File by adding or removing
+     * NITF Image Segments without updating the mapping of cameras and temporal
+     * blocks to NITF Image Segments specified in the MTIMFA TRE (defined in
+     * Section 5.9.3.5). Tools that understand MIE4NITF shall properly update
+     * both this TRE and the MTIMFA TRE whenever NITF Image Segments are added
+     * or removed from the NITF File.
+     *
+     * @return image segment index of the segment containing this camera and
+     * temporal block.
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final int getImageSegmentIndex() throws NitfFormatException {
+        return getValueAsInteger("IMAGE_SEG_INDEX");
+    }
+
+    /**
+     * Whether the geo-coordinates for this image segment are static.
+     *
+     * From MIE4NITF Version 1.1: GEOCOORDS_STATIC – A flag indicating if the
+     * geo-coordinates associated with this NITF Image Segment may be considered
+     * static or unchanging across the MI frames contained in this Image
+     * Segment. A value of 00 indicates the geo-coordinates are not static and a
+     * value of 99 indicates they are. All other values are reserved for future
+     * use. Note the definition of “static” is at the discretion of the data
+     * producer. Small amounts of scene jitter may be ignored and the scene
+     * considered static in some use cases. In others, the same amount of jitter
+     * may not be considered static.
+     *
+     * @return true if coordinates are static ("99"), otherwise false.
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final boolean geoCoordinatesAreStatic() throws NitfFormatException {
+        return getFieldValue("GEOCOORDS_STATIC").equals("99");
+    }
+
+    /**
+     * Get the phenomenological layer for this image segment.
+     *
+     * From MIE4NITF Version 1.1: LAYER_ID – The ID token of the
+     * phenomenological layer associated with the camera for which this NITF
+     * Image Segment contains MI data.
+     *
+     * @return the layer identifier (usually a GUID), or all spaces for a
+     * quicklook image
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final String getLayerId() throws NitfFormatException {
+        return getFieldValue("LAYER_ID");
+    }
+
+    /**
+     * Get the camera set index for this image segment.
+     *
+     * From MIE4NITF Version 1.1: CAMERA_SET_INDEX – The index of the camera set
+     * associated with the camera for which this NITF Image Segment contains MI
+     * data.
+     *
+     * @return the camera set index for this image segment, or 0 for quicklook
+     * image
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final int getCameraSetIndex() throws NitfFormatException {
+        return getValueAsInteger("CAMERA_SET_INDEX");
+    }
+
+    /**
+     * Get the camera identifier.
+     *
+     * From MIE4NITF Version 1.1: CAMERA_ID – The UUID of the camera for which
+     * this NITF Image Segment contains MI data.
+     *
+     * @return camera UUID, or all spaces for a quicklook image.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final String getCameraIdentifier() throws NitfFormatException {
+        return getFieldValue("CAMERA_ID");
+    }
+
+    /**
+     * Get the time interval index for this image segment.
+     *
+     * From MIE4NITF Version 1.1: TIME_INTERVAL_INDEX – The index of the time
+     * interval in which the temporal block corresponding to this NITF Image
+     * Segment is contained.
+     *
+     * @return time interval index, or 0 for a quicklook image.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final int getTimeIntervalIndex() throws NitfFormatException {
+        return getValueAsInteger("TIME_INTERVAL_INDEX");
+    }
+
+    /**
+     * Get the temporal block index for this image segment.
+     *
+     * From MIE4NITF Version 1.1: TEMP_BLOCK_INDEX – The index of the temporal
+     * block corresponding to this NITF Image Segment.
+     *
+     * @return the temporal block index, or 0 for a quicklook image.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final int getTemporalBlockIndex() throws NitfFormatException {
+        return getValueAsInteger("TEMP_BLOCK_INDEX");
+    }
+
+    /**
+     * Get the nominal frame rate for this image segment.
+     *
+     * From MIE4NITF Version 1.1: NOMINAL_FRAME_RATE – The nominal frame rate of
+     * the data contained in this NITF Image Segment, specified in frames per
+     * second. If the nominal frame rate is not known or the collection is
+     * driven by asynchronous external events, the value of the field may be
+     * “NaN” followed by BCS-A spaces, see Table 10.
+     *
+     * @return the nominal frame rate, or -1.0 if there is no valid frame rate.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final double getNominalFrameRate() throws NitfFormatException {
+        if (mTre.getFieldValue("NOMINAL_FRAME_RATE").trim().equals("NaN")) {
+            return -1.0;
+        }
+        return mTre.getDoubleValue("NOMINAL_FRAME_RATE");
+    }
+
+    /**
+     * Get the reference frame number.
+     *
+     * From MIE4NITF Version 1.1: REFERENCE_FRAME_NUM – The absolute reference
+     * frame number of the first frame in this temporal block for this camera,
+     * as specified by the collection system. If the collection system does not
+     * use absolute frame numbers, then this field is BCS-A spaces filled. The
+     * absolute frame number for any frame in this NITF Image Segment, if a
+     * reference frame number is specified, is equal to REFERENCE_FRAME_NUM + n
+     * – 1, where n is the one-based index of that frame in this NITF Image
+     * Segment.
+     *
+     * @return the reference frame number, or -1 if there are no absolute frame
+     * numbers.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final int getReferenceFrameNumber() throws NitfFormatException {
+        if (getValueAsTrimmedString("REFERENCE_FRAME_NUM").isEmpty()) {
+            return -1;
+        }
+        return getValueAsInteger("REFERENCE_FRAME_NUM");
+    }
+
+    /**
+     * Get the base timestamp for this temporal block.
+     *
+     * From MIE4NITF Version 1.1: BASE_TIMESTAMP – A base timestamp from which
+     * the timestamps for each of the individual frames in this temporal block
+     * for this camera are calculated (see equation (1)). Timestamps are always
+     * correspond to the start of collection of a frame, as defined by the
+     * collection system. Only the proper level of meaningful precision should
+     * be used in the timestamps, see Table 9.
+     *
+     * @return the base timestamp.
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final ZonedDateTime getBaseTimestamp() throws NitfFormatException {
+        return getValueAsZonedDateTime("BASE_TIMESTAMP", TIMESTAMP_NANO_FORMATTER);
+    }
+
+    /**
+     * Get the delta time multiplier.
+     *
+     * From MIE4NITF Version 1.1: DT_MULTIPLIER – The number of nanoseconds
+     * equal to 1 delta time unit.
+     *
+     * The number of nanoseconds equal to one time unit, or minimum “delta time”
+     * that can be expressed between frames.
+     *
+     * Note that this can potentially overflow a long integer when converting.
+     *
+     * @return delta time in nanoseconds per unit
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final BigInteger getDeltaTimeMultiplier() throws NitfFormatException {
+        return getValueAsBigInteger("DT_MULTIPLIER");
+    }
+
+    /**
+     * Get the number of frames in this image segment.
+     *
+     * From MIE4NITF Version 1.1: NUM_FRAMES – The number of frames in this NITF
+     * Image Segment for this camera and temporal block.
+     *
+     * @return the number of frames
+     * @throws NitfFormatException if there was an issue during parsing
+     */
+    public final long getNumberOfFrames() throws NitfFormatException {
+        return getValueAsLongInteger("NUMBER_FRAMES");
+    }
+
+    /**
+     * Get the number of delta time entries.
+     *
+     * From MIE4NITF Version 1.1: NUMBER_DT – The number of delta time unit
+     * values contained in this NITF Image Segment for this camera and temporal
+     * block. The value of this field must be either equal to NUM_FRAMES or must
+     * be 1. If the value is equal to NUM_FRAMES, then a separate DTn value is
+     * specified for each frame. If the value is 1, then only a single DTn value
+     * is specified, which applies to every frame. This indicates that the
+     * frames for this camera in this temporal block are evenly spaced
+     * temporally.
+     *
+     * @return the number of delta times
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final long getNumberOfDeltaTimes() throws NitfFormatException {
+        return getValueAsLongInteger("NUMBER_DT");
+    }
+
+    /**
+     * Get a specific delta time.
+     *
+     * From MIE4NITF Version 1.1: DTn – The number of delta time units between
+     * this frame and the previous frame. The number of DTn values must be equal
+     * to the value of the NUMBER_DT field. The values are expressed as fixed
+     * length unsigned integers ranging from one to eight bytes in length.
+     * DT_SIZE determines the number of bytes used for the DTn values. For a
+     * given MTIMSA TRE, the number of bytes for each DTn is fixed, but the
+     * number of bytes used for DTn can change between different MTIMSA TREs.
+     *
+     * @param deltaItemIndex the zero-based index of the delta time to retrieve.
+     * @return the delta time.
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final BigInteger getDeltaTime(final long deltaItemIndex) throws NitfFormatException {
+        List<TreGroup> deltaTimes = mTre.getEntry("DELTA_TIME").getGroups();
+        TreGroup deltaTimeGroup = deltaTimes.get((int) deltaItemIndex);
+        return deltaTimeGroup.getBigIntegerValue("DT");
+    }
+
+    /**
+     * Get the timestamp for a specified frame.
+     *
+     * @param frameIndex the frame index (one-based) to get the timestamp for.
+     * @return UTC date-time for the frame
+     * @throws NitfFormatException if there was an issue during parsing.
+     */
+    public final ZonedDateTime getFrameTime(final long frameIndex) throws NitfFormatException {
+        if (getNumberOfDeltaTimes() == 1L) {
+            // Equal time between frames
+            ZonedDateTime timeStamp = getBaseTimestamp();
+            BigInteger nanoseconds = getDeltaTime(0).multiply(getDeltaTimeMultiplier()).multiply(BigInteger.valueOf(frameIndex));
+            return addNanoSeconds(nanoseconds, timeStamp);
+        } else {
+            ZonedDateTime timeStamp = getBaseTimestamp();
+            for (long i = 0; i < frameIndex; ++i) {
+                BigInteger nanoseconds = getDeltaTime(i).multiply(getDeltaTimeMultiplier());
+                timeStamp = addNanoSeconds(nanoseconds, timeStamp);
+            }
+            return timeStamp;
+        }
+    }
+
+    private ZonedDateTime addNanoSeconds(final BigInteger nanoseconds, final ZonedDateTime timeStamp) {
+        BigInteger seconds = nanoseconds.divide(NANOSECONDS_IN_ONE_SECOND);
+        BigInteger nanoRemainder = nanoseconds.mod(NANOSECONDS_IN_ONE_SECOND);
+        return timeStamp.plusSeconds(seconds.longValueExact()).plusNanos(nanoRemainder.longValueExact());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final ValidityResult getValidity() throws NitfFormatException {
+        ValidityResult validity = new ValidityResult();
+        if ((getNumberOfDeltaTimes() != 1L) && (getNumberOfDeltaTimes() != getNumberOfFrames())) {
+            validity.setValidityStatus(ValidityResult.ValidityStatus.NOT_VALID);
+            validity.setValidityResultDescription("Number of delta times must equal number of frames, or be 1.");
+        }
+        return validity;
+    }
+
+}

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/PIAPEB.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/PIAPEB.java
@@ -57,11 +57,11 @@ public class PIAPEB extends FlatTreWrapper {
     public PIAPEB(final TreSource treSource) throws NitfFormatException {
         super(TAG_NAME, treSource);
         // set default values
-        addOrUpdateEntry("LASTNME", "");
-        addOrUpdateEntry("FIRSTNME", "");
-        addOrUpdateEntry("MIDNME", "");
-        addOrUpdateEntry("DOB", "");
-        addOrUpdateEntry("ASSOCTRY", "");
+        addOrUpdateEntry("LASTNME", "", "string");
+        addOrUpdateEntry("FIRSTNME", "", "string");
+        addOrUpdateEntry("MIDNME", "", "string");
+        addOrUpdateEntry("DOB", "", "string");
+        addOrUpdateEntry("ASSOCTRY", "", "string");
     }
 
     /**
@@ -73,7 +73,7 @@ public class PIAPEB extends FlatTreWrapper {
      * @throws NitfFormatException if there is a parsing issue.
      */
     public final void setLastName(final String lastName) throws NitfFormatException {
-        addOrUpdateEntry("LASTNME", lastName);
+        addOrUpdateEntry("LASTNME", lastName, "string");
     }
 
     /**
@@ -97,7 +97,7 @@ public class PIAPEB extends FlatTreWrapper {
      * @throws NitfFormatException if there is a parsing issue.
      */
     public final void setFirstName(final String firstName) throws NitfFormatException {
-        addOrUpdateEntry("FIRSTNME", firstName);
+        addOrUpdateEntry("FIRSTNME", firstName, "string");
     }
 
     /**
@@ -121,7 +121,7 @@ public class PIAPEB extends FlatTreWrapper {
      * @throws NitfFormatException if there is a parsing issue.
      */
     public final void setMiddleName(final String middleName) throws NitfFormatException {
-        addOrUpdateEntry("MIDNME", middleName);
+        addOrUpdateEntry("MIDNME", middleName, "string");
     }
 
     /**
@@ -176,7 +176,7 @@ public class PIAPEB extends FlatTreWrapper {
      * @throws NitfFormatException if there is a parsing issue.
      */
     public final void setAssociatedCountry(final String associatedCountry) throws NitfFormatException {
-        addOrUpdateEntry("ASSOCTRY", associatedCountry);
+        addOrUpdateEntry("ASSOCTRY", associatedCountry, "string");
     }
 
     /**

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/TreWrapper.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/TreWrapper.java
@@ -114,7 +114,7 @@ public abstract class TreWrapper {
      * @throws NitfFormatException if the field was not found or a parsing issue occurs.
      */
     protected final long getValueAsLongInteger(final String fieldName) throws NitfFormatException {
-        return mTre.getLongIntegerValue(fieldName);
+        return mTre.getLongValue(fieldName);
     }
 
     /**

--- a/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/TreWrapper.java
+++ b/trewrap/src/main/java/org/codice/imaging/nitf/trewrap/TreWrapper.java
@@ -14,6 +14,7 @@
  */
 package org.codice.imaging.nitf.trewrap;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -39,6 +40,11 @@ public abstract class TreWrapper {
      * Internal constant for date formatting / parsing in four digit year, month, day, hours, minutes convention.
      */
     protected static final DateTimeFormatter CENTURY_DATE_TIME_MINUTES_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
+
+    /**
+     * Internal constant for date formatting / parsing in UTC to nanosecond precision format.
+     */
+    protected static final DateTimeFormatter TIMESTAMP_NANO_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss.nnnnnnnnn");
 
     /**
      * The TRE that is being wrapped.
@@ -98,6 +104,28 @@ public abstract class TreWrapper {
      */
     protected final int getValueAsInteger(final String fieldName) throws NitfFormatException {
         return mTre.getIntValue(fieldName);
+    }
+
+    /**
+     * Retrieve the specified value as a long integer field.
+     *
+     * @param fieldName the name of the field value to retrieve.
+     * @return the value for the TRE entry.
+     * @throws NitfFormatException if the field was not found or a parsing issue occurs.
+     */
+    protected final long getValueAsLongInteger(final String fieldName) throws NitfFormatException {
+        return mTre.getLongIntegerValue(fieldName);
+    }
+
+    /**
+     * Retrieve the specified value as an arbitrary precision (BigInteger) field.
+     *
+     * @param fieldName the name of the field value to retrieve.
+     * @return the value for the TRE entry.
+     * @throws NitfFormatException if the field was not found or a parsing issue occurs.
+     */
+    protected final BigInteger getValueAsBigInteger(final String fieldName) throws NitfFormatException {
+        return mTre.getBigIntegerValue(fieldName);
     }
 
     /**

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.trewrap;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import static javax.xml.bind.DatatypeConverter.parseHexBinary;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.tre.Tre;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * Tests for the MTIMSA TRE wrapper.
+ */
+public class MTIMSA_WrapTest extends SharedTreTestSupport {
+
+    public MTIMSA_WrapTest() {
+    }
+
+    @Test
+    public void basicParse() throws IOException, NitfFormatException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write("MTIMSA0016000199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e840000030045.0000000E+0100000000620160716215756.012345678".getBytes(StandardCharsets.US_ASCII));
+        baos.write(parseHexBinary("0000000001312D00"));
+        baos.write(parseHexBinary("01"));
+        baos.write(parseHexBinary("01020304"));
+        baos.write(parseHexBinary("00000001"));
+        baos.write(parseHexBinary("4e"));
+        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 171, "MTIMSA");
+        MTIMSA mtimsa = new MTIMSA(tre);
+        assertTrue(mtimsa.getValidity().isValid());
+        assertEquals(1, mtimsa.getImageSegmentIndex());
+        assertTrue(mtimsa.geoCoordinatesAreStatic());
+        assertEquals("fa238862-73ed-41fc-8d52-bfc7a954428c", mtimsa.getLayerId());
+        assertEquals(2, mtimsa.getCameraSetIndex());
+        assertEquals("95cb5511-7350-479b-9c8a-f028aba01e84", mtimsa.getCameraIdentifier());
+        assertEquals(3, mtimsa.getTimeIntervalIndex());
+        assertEquals(4, mtimsa.getTemporalBlockIndex());
+        assertEquals(50.0, mtimsa.getNominalFrameRate(), 0.00001);
+        assertEquals(6, mtimsa.getReferenceFrameNumber());
+        ZonedDateTime expectedBaseTimestamp = ZonedDateTime.of(2016, 7, 16, 21, 57, 56, 12345678, ZoneId.of("UTC"));
+        ZonedDateTime actualBaseTimestamp = mtimsa.getBaseTimestamp();
+        assertEquals(expectedBaseTimestamp, actualBaseTimestamp);
+        assertEquals(20000000, mtimsa.getDeltaTimeMultiplier().intValueExact());
+        assertEquals(16909060, mtimsa.getNumberOfFrames());
+        assertEquals(1, mtimsa.getNumberOfDeltaTimes());
+        assertEquals(BigInteger.valueOf(78L), mtimsa.getDeltaTime(0));
+        ZonedDateTime expectedFrame1Time = ZonedDateTime.of(2016, 7, 16, 21, 57, 57, 572345678, ZoneId.of("UTC"));
+        assertEquals(expectedFrame1Time, mtimsa.getFrameTime(1));
+    }
+
+    @Test
+    public void basicNaNAltData() throws IOException, NitfFormatException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        baos.write("MTIMSA0016000199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e84000003004NaN                   20160716215756.012345678".getBytes(StandardCharsets.US_ASCII));
+        baos.write(parseHexBinary("0000000001312D00"));
+        baos.write(parseHexBinary("03"));
+        baos.write(parseHexBinary("01020304"));
+        baos.write(parseHexBinary("00000003"));
+        baos.write(parseHexBinary("4e0245"));
+        baos.write(parseHexBinary("fe0245"));
+
+        baos.write(parseHexBinary("3e0245"));
+        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 171, "MTIMSA");
+        MTIMSA mtimsa = new MTIMSA(tre);
+        assertFalse(mtimsa.getValidity().isValid());
+        assertEquals(-1.0, mtimsa.getNominalFrameRate(), 0.00001);
+        assertEquals(-1, mtimsa.getReferenceFrameNumber());
+
+        ZonedDateTime expectedBaseTimestamp = ZonedDateTime.of(2016, 7, 16, 21, 57, 56, 12345678, ZoneId.of("UTC"));
+        ZonedDateTime actualBaseTimestamp = mtimsa.getBaseTimestamp();
+        assertEquals(expectedBaseTimestamp, actualBaseTimestamp);
+        assertEquals(20000000, mtimsa.getDeltaTimeMultiplier().intValueExact());
+        assertEquals(16909060, mtimsa.getNumberOfFrames());
+        assertEquals(3, mtimsa.getNumberOfDeltaTimes());
+        assertEquals(BigInteger.valueOf(5112389L), mtimsa.getDeltaTime(0));
+        assertEquals(BigInteger.valueOf(16646725L), mtimsa.getDeltaTime(1));
+        assertEquals(BigInteger.valueOf(4063813L), mtimsa.getDeltaTime(2));
+
+        ZonedDateTime expectedFrame3Time = ZonedDateTime.of(2016, 7, 22, 21, 25, 34, 552345678, ZoneId.of("UTC"));
+        assertEquals(expectedFrame3Time, mtimsa.getFrameTime(3));
+    }
+}

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SharedTreTestSupport.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/SharedTreTestSupport.java
@@ -37,10 +37,14 @@ public abstract class SharedTreTestSupport {
 
     protected Tre parseTRE(String testData, String treTag) throws NitfFormatException {
         InputStream inputStream = new ByteArrayInputStream(testData.getBytes());
+        return parseTRE(inputStream, testData.length(), treTag);
+    }
+
+    protected Tre parseTRE(InputStream inputStream, int len, String treTag) throws NitfFormatException {
         BufferedInputStream bufferedStream = new BufferedInputStream(inputStream);
         NitfReader nitfReader = new NitfInputStreamReader(bufferedStream);
         TreCollectionParser parser = new TreCollectionParser();
-        TreCollection parseResult = parser.parse(nitfReader, testData.length(), TreSource.ImageExtendedSubheaderData);
+        TreCollection parseResult = parser.parse(nitfReader, len, TreSource.ImageExtendedSubheaderData);
         assertEquals(1, parseResult.getTREs().size());
         Tre tre = parseResult.getTREsWithName(treTag).get(0);
         assertNotNull(tre);


### PR DESCRIPTION
This extends the parser to handle unsigned integer (big endian) binary as "UINT", for
whatever the specified length is.