### PR TITLE
[IMG-146] Add label segment factory.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentFactory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/ImageSegmentFactory.java
@@ -36,7 +36,7 @@ public final class ImageSegmentFactory {
      * valid - it is application dependent.
      *
      * @param fileType the type (version) of NITF file this image segment is for
-     * @return default valid image segment, containing no image data.
+     * @return default image segment, containing no image data.
      */
     public static ImageSegment getDefault(final FileType fileType) {
         ImageSegment imageSegment = new ImageSegmentImpl();

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegment.java
@@ -17,102 +17,208 @@ package org.codice.imaging.nitf.core.label;
 import org.codice.imaging.nitf.core.RGBColour;
 import org.codice.imaging.nitf.core.common.CommonBasicSegment;
 
-
 /**
- Label segment subheader information (NITF 2.0 only).
+ * Label segment subheader information (NITF 2.0 only).
  */
 public interface LabelSegment extends CommonBasicSegment {
 
     /**
-     Return the row part of the label location (LLOC).
-     <p>
-     "A label's location specified by providing the location of the upper left corner of the
-     minimum bounding rectangle of the label. This field shall contain the label location
-     represented as rrrrrccccc, where rrrrr and ccccc are the row and the column offset
-     from the ILOC, SLOC, or LLOC value of the item to which the label is attached.
-     A row or column value of 00000 indicates no offset. Positive row and column
-     values indicate offsets down and to the right and range from 00001 to 99999, while
-     negative row and column values indicate offsets up and to the left and must be
-     within the range -0001 to -9999. The coordinate system used to express ILOC,
-     SLOC, and LLOC fields shall be common for all images, labels, and symbols in the
-     file having attachment level zero. The location in this common coordinate system
-     of all displayable graphic components can be computed from the offsets given in the
-     ILOC, SLOC, and LLOC fields."
+     * Set the column part of the label location (LLOC).
+     * <p>
+     * "A label's location specified by providing the location of the upper left
+     * corner of the minimum bounding rectangle of the label. This field shall
+     * contain the label location represented as rrrrrccccc, where rrrrr and
+     * ccccc are the row and the column offset from the ILOC, SLOC, or LLOC
+     * value of the item to which the label is attached. A row or column value
+     * of 00000 indicates no offset. Positive row and column values indicate
+     * offsets down and to the right and range from 00001 to 99999, while
+     * negative row and column values indicate offsets up and to the left and
+     * must be within the range -0001 to -9999. The coordinate system used to
+     * express ILOC, SLOC, and LLOC fields shall be common for all images,
+     * labels, and symbols in the file having attachment level zero. The
+     * location in this common coordinate system of all displayable graphic
+     * components can be computed from the offsets given in the ILOC, SLOC, and
+     * LLOC fields."
+     *
+     * @param columnNumber the column number for the label location.
+     */
+    void setLabelLocationColumn(final int columnNumber);
 
-     @return the row number for the label location.
+    /**
+     * Set the row part of the label location (LLOC).
+     * <p>
+     * "A label's location specified by providing the location of the upper left
+     * corner of the minimum bounding rectangle of the label. This field shall
+     * contain the label location represented as rrrrrccccc, where rrrrr and
+     * ccccc are the row and the column offset from the ILOC, SLOC, or LLOC
+     * value of the item to which the label is attached. A row or column value
+     * of 00000 indicates no offset. Positive row and column values indicate
+     * offsets down and to the right and range from 00001 to 99999, while
+     * negative row and column values indicate offsets up and to the left and
+     * must be within the range -0001 to -9999. The coordinate system used to
+     * express ILOC, SLOC, and LLOC fields shall be common for all images,
+     * labels, and symbols in the file having attachment level zero. The
+     * location in this common coordinate system of all displayable graphic
+     * components can be computed from the offsets given in the ILOC, SLOC, and
+     * LLOC fields."
+     *
+     * @param rowNumber the row number for the label location.
+     */
+    void setLabelLocationRow(final int rowNumber);
+
+    /**
+     * Return the row part of the label location (LLOC).
+     * <p>
+     * "A label's location specified by providing the location of the upper left
+     * corner of the minimum bounding rectangle of the label. This field shall
+     * contain the label location represented as rrrrrccccc, where rrrrr and
+     * ccccc are the row and the column offset from the ILOC, SLOC, or LLOC
+     * value of the item to which the label is attached. A row or column value
+     * of 00000 indicates no offset. Positive row and column values indicate
+     * offsets down and to the right and range from 00001 to 99999, while
+     * negative row and column values indicate offsets up and to the left and
+     * must be within the range -0001 to -9999. The coordinate system used to
+     * express ILOC, SLOC, and LLOC fields shall be common for all images,
+     * labels, and symbols in the file having attachment level zero. The
+     * location in this common coordinate system of all displayable graphic
+     * components can be computed from the offsets given in the ILOC, SLOC, and
+     * LLOC fields."
+     *
+     * @return the row number for the label location.
      */
     int getLabelLocationRow();
 
-
     /**
-     Return the column part of the label location (LLOC).
-     <p>
-     "A label's location specified by providing the location of the upper left corner of the
-     minimum bounding rectangle of the label. This field shall contain the label location
-     represented as rrrrrccccc, where rrrrr and ccccc are the row and the column offset
-     from the ILOC, SLOC, or LLOC value of the item to which the label is attached.
-     A row or column value of 00000 indicates no offset. Positive row and column
-     values indicate offsets down and to the right and range from 00001 to 99999, while
-     negative row and column values indicate offsets up and to the left and must be
-     within the range -0001 to -9999. The coordinate system used to express ILOC,
-     SLOC, and LLOC fields shall be common for all images, labels, and symbols in the
-     file having attachment level zero. The location in this common coordinate system
-     of all displayable graphic components can be computed from the offsets given in the
-     ILOC, SLOC, and LLOC fields."
-
-     @return the column number for the label location.
+     * Return the column part of the label location (LLOC).
+     * <p>
+     * "A label's location specified by providing the location of the upper left
+     * corner of the minimum bounding rectangle of the label. This field shall
+     * contain the label location represented as rrrrrccccc, where rrrrr and
+     * ccccc are the row and the column offset from the ILOC, SLOC, or LLOC
+     * value of the item to which the label is attached. A row or column value
+     * of 00000 indicates no offset. Positive row and column values indicate
+     * offsets down and to the right and range from 00001 to 99999, while
+     * negative row and column values indicate offsets up and to the left and
+     * must be within the range -0001 to -9999. The coordinate system used to
+     * express ILOC, SLOC, and LLOC fields shall be common for all images,
+     * labels, and symbols in the file having attachment level zero. The
+     * location in this common coordinate system of all displayable graphic
+     * components can be computed from the offsets given in the ILOC, SLOC, and
+     * LLOC fields."
+     *
+     * @return the column number for the label location.
      */
     int getLabelLocationColumn();
 
     /**
-     Returns the label cell width (LCW) of the label.
-     <p>
-     "This field shall contain the width in pixels of the character cell (rectangular array
-     used to contain a single character in monospaced fonts) used by the file originator.
-     The default value of 00 indicates the file originator has not included this information."
+     * Set the label cell height (LCH) of the label.
+     * <p>
+     * "This field shall contain the height in pixels of the character cell
+     * (rectangular array used to contain a single character in monospaced
+     * fonts) used by the file originator. The default value of 00 indicates the
+     * file originator has not included this information."
+     *
+     * @param cellHeight cell height
+     *
+     */
+    void setLabelCellHeight(final int cellHeight);
 
-     @return cell width (default 0, not set)
+    /**
+     * Set the label cell width (LCW) of the label.
+     * <p>
+     * "This field shall contain the width in pixels of the character cell
+     * (rectangular array used to contain a single character in monospaced
+     * fonts) used by the file originator. The default value of 00 indicates the
+     * file originator has not included this information."
+     *
+     * @param cellWidth cell width
+     */
+    void setLabelCellWidth(final int cellWidth);
+
+    /**
+     * Returns the label cell width (LCW) of the label.
+     * <p>
+     * "This field shall contain the width in pixels of the character cell
+     * (rectangular array used to contain a single character in monospaced
+     * fonts) used by the file originator. The default value of 00 indicates the
+     * file originator has not included this information."
+     *
+     * @return cell width (default 0, not set)
      */
     int getLabelCellWidth();
 
     /**
-     Returns the label cell height (LCH) of the label.
-     <p>
-     "This field shall contain the height in pixels of the character cell (rectangular array
-     used to contain a single character in monospaced fonts) used by the file originator.
-     The default value of 00 indicates the file originator has not included this information."
-
-     @return cell height (default 0, not set)
-     **/
+     * Returns the label cell height (LCH) of the label.
+     * <p>
+     * "This field shall contain the height in pixels of the character cell
+     * (rectangular array used to contain a single character in monospaced
+     * fonts) used by the file originator. The default value of 00 indicates the
+     * file originator has not included this information."
+     *
+     * @return cell height (default 0, not set)
+     *
+     */
     int getLabelCellHeight();
 
     /**
-     Return the label display level (LDLVL).
-     <p>
-     "This field shall contain a valid value that indicates the graphic display level of the
-     label relative to other displayed file components in a composite display. The valid
-     values are 001 to 999. The display level of each displayable file component (image,
-     label, symbol) within a file shall be unique; that is, each number from 001 to 999 is
-     the display level of, at most, one item. The meaning of display level is discussed
-     fully in 5.3.3. The symbol, image, or label component in the file having the
-     minimum display level shall have attachment level zero (ILOC, SLOC, and LLOC
-     field descriptions)."
+     * Set the label display level (LDLVL).
+     * <p>
+     * "This field shall contain a valid value that indicates the graphic
+     * display level of the label relative to other displayed file components in
+     * a composite display. The valid values are 001 to 999. The display level
+     * of each displayable file component (image, label, symbol) within a file
+     * shall be unique; that is, each number from 001 to 999 is the display
+     * level of, at most, one item. The meaning of display level is discussed
+     * fully in 5.3.3. The symbol, image, or label component in the file having
+     * the minimum display level shall have attachment level zero (ILOC, SLOC,
+     * and LLOC field descriptions)."
+     *
+     * @param displayLevel the label display level
+     */
+    void setLabelDisplayLevel(final int displayLevel);
 
-     @return the label display level
+    /**
+     * Return the label display level (LDLVL).
+     * <p>
+     * "This field shall contain a valid value that indicates the graphic
+     * display level of the label relative to other displayed file components in
+     * a composite display. The valid values are 001 to 999. The display level
+     * of each displayable file component (image, label, symbol) within a file
+     * shall be unique; that is, each number from 001 to 999 is the display
+     * level of, at most, one item. The meaning of display level is discussed
+     * fully in 5.3.3. The symbol, image, or label component in the file having
+     * the minimum display level shall have attachment level zero (ILOC, SLOC,
+     * and LLOC field descriptions)."
+     *
+     * @return the label display level
      */
     int getLabelDisplayLevel();
 
     /**
-     Return the label text colour.
+     * Set the label text colour.
+     *
+     * @param textColour the text colour.
+     */
+    void setLabelTextColour(final RGBColour textColour);
 
-     @return the text colour.
+    /**
+     * Return the label text colour.
+     *
+     * @return the text colour.
      */
     RGBColour getLabelTextColour();
 
     /**
-     Return the label background colour.
+     * Set the label background colour.
+     *
+     * @param backgroundColour the background colour.
+     */
+    void setLabelBackgroundColour(final RGBColour backgroundColour);
 
-     @return the background colour.
+    /**
+     * Return the label background colour.
+     *
+     * @return the background colour.
      */
     RGBColour getLabelBackgroundColour();
 
@@ -129,4 +235,5 @@ public interface LabelSegment extends CommonBasicSegment {
      * @param labelData to set
      */
     void setData(String labelData);
+
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentFactory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.label;
+
+import org.codice.imaging.nitf.core.RGBColour;
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.security.SecurityMetadataFactory;
+
+/**
+ * Factory class for creating new TextSegment instances.
+ */
+public final class LabelSegmentFactory {
+
+
+    private LabelSegmentFactory() {
+    }
+
+    /**
+     * Create a default NITF label segment, without data.
+     *
+     * This only applies to NITF 2.0 files, so that is assumed.
+     *
+     * Note that this will not set an identifier (LID) - it will be empty (space
+     * filled on write). That may or may not be valid - it is application
+     * dependent.
+     *
+     * Location (column and row) will be set 0 (no offset).
+     * Cell height and cell width will have the default "0" value.
+     * Attachment level will be set to 0 (not attached).
+     * Text background colour will be set to black, and text foreground colour will be set to blue.
+     *
+     * Display level will be set to 0, which is not valid, and must be set prior to writing out the label segment.
+     * @return default label segment, containing no text data.
+     */
+    public static LabelSegment getDefault() {
+        LabelSegment labelSegment = new LabelSegmentImpl();
+        labelSegment.setFileType(FileType.NITF_TWO_ZERO);
+        labelSegment.setSecurityMetadata(SecurityMetadataFactory.getDefaultMetadata(FileType.NITF_TWO_ZERO));
+        labelSegment.setIdentifier("");
+        labelSegment.setAttachmentLevel(0);
+        labelSegment.setLabelBackgroundColour(new RGBColour((byte) 0, (byte) 0, (byte) 0));
+        labelSegment.setLabelTextColour(new RGBColour(RGBColour.CODICE_LOGO_RED_COMPONENT,
+                RGBColour.CODICE_LOGO_GREEN_COMPONENT,
+                RGBColour.CODICE_LOGO_BLUE_COMPONENT));
+        return labelSegment;
+    }
+}

--- a/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/label/LabelSegmentImpl.java
@@ -43,23 +43,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-        Set the row part of the label location (LLOC).
-        <p>
-        "A label's location specified by providing the location of the upper left corner of the
-        minimum bounding rectangle of the label. This field shall contain the label location
-        represented as rrrrrccccc, where rrrrr and ccccc are the row and the column offset
-        from the ILOC, SLOC, or LLOC value of the item to which the label is attached.
-        A row or column value of 00000 indicates no offset. Positive row and column
-        values indicate offsets down and to the right and range from 00001 to 99999, while
-        negative row and column values indicate offsets up and to the left and must be
-        within the range -0001 to -9999. The coordinate system used to express ILOC,
-        SLOC, and LLOC fields shall be common for all images, labels, and symbols in the
-        file having attachment level zero. The location in this common coordinate system
-        of all displayable graphic components can be computed from the offsets given in the
-        ILOC, SLOC, and LLOC fields."
-
-        @param rowNumber the row number for the label location.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelLocationRow(final int rowNumber) {
         labelLocationRow = rowNumber;
     }
@@ -73,23 +59,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-        Set the column part of the label location (LLOC).
-        <p>
-        "A label's location specified by providing the location of the upper left corner of the
-        minimum bounding rectangle of the label. This field shall contain the label location
-        represented as rrrrrccccc, where rrrrr and ccccc are the row and the column offset
-        from the ILOC, SLOC, or LLOC value of the item to which the label is attached.
-        A row or column value of 00000 indicates no offset. Positive row and column
-        values indicate offsets down and to the right and range from 00001 to 99999, while
-        negative row and column values indicate offsets up and to the left and must be
-        within the range -0001 to -9999. The coordinate system used to express ILOC,
-        SLOC, and LLOC fields shall be common for all images, labels, and symbols in the
-        file having attachment level zero. The location in this common coordinate system
-        of all displayable graphic components can be computed from the offsets given in the
-        ILOC, SLOC, and LLOC fields."
-
-        @param columnNumber the column number for the label location.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelLocationColumn(final int columnNumber) {
         labelLocationColumn = columnNumber;
     }
@@ -103,14 +75,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-      Set the label cell width (LCW) of the label.
-      <p>
-       "This field shall contain the width in pixels of the character cell (rectangular array
-       used to contain a single character in monospaced fonts) used by the file originator.
-       The default value of 00 indicates the file originator has not included this information."
-
-      @param cellWidth cell width
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelCellWidth(final int cellWidth) {
         labelCellWidth = cellWidth;
     }
@@ -124,14 +91,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-      Set the label cell height (LCH) of the label.
-      <p>
-        "This field shall contain the height in pixels of the character cell (rectangular array
-        used to contain a single character in monospaced fonts) used by the file originator.
-        The default value of 00 indicates the file originator has not included this information."
-
-      @param cellHeight cell height
-    **/
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelCellHeight(final int cellHeight) {
         labelCellHeight = cellHeight;
     }
@@ -145,19 +107,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-        Set the label display level (LDLVL).
-        <p>
-        "This field shall contain a valid value that indicates the graphic display level of the
-        label relative to other displayed file components in a composite display. The valid
-        values are 001 to 999. The display level of each displayable file component (image,
-        label, symbol) within a file shall be unique; that is, each number from 001 to 999 is
-        the display level of, at most, one item. The meaning of display level is discussed
-        fully in 5.3.3. The symbol, image, or label component in the file having the
-        minimum display level shall have attachment level zero (ILOC, SLOC, and LLOC
-        field descriptions)."
-
-        @param displayLevel the label display level
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelDisplayLevel(final int displayLevel) {
         labelDisplayLevel = displayLevel;
     }
@@ -171,10 +123,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-        Set the label text colour.
-
-        @param textColour the text colour.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelTextColour(final RGBColour textColour) {
         labelTextColour = textColour;
     }
@@ -188,10 +139,9 @@ class LabelSegmentImpl extends CommonBasicSegmentImpl implements LabelSegment {
     }
 
     /**
-        Set the label background colour.
-
-        @param backgroundColour the background colour.
-    */
+     * {@inheritDoc}
+     */
+    @Override
     public final void setLabelBackgroundColour(final RGBColour backgroundColour) {
         labelBackgroundColour = backgroundColour;
     }

--- a/core/src/test/java/org/codice/imaging/nitf/core/label/LabelSegmentFactoryTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/label/LabelSegmentFactoryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.label;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import org.codice.imaging.nitf.core.common.FileType;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.security.SecurityClassification;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ * Tests for the LabelSegmentFactory.
+ */
+public class LabelSegmentFactoryTest {
+
+    // Avoid test coverage problem
+    @Test
+    public void testConstructorIsPrivate() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<LabelSegmentFactory> constructor = LabelSegmentFactory.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
+
+    @Test
+    public void checkDefaultBuild() throws NitfFormatException {
+        LabelSegment segment = LabelSegmentFactory.getDefault();
+        assertNotNull(segment);
+        assertEquals(FileType.NITF_TWO_ZERO, segment.getFileType());
+        assertEquals("", segment.getIdentifier());
+        assertEquals(SecurityClassification.UNCLASSIFIED, segment.getSecurityMetadata().getSecurityClassification());
+        assertEquals(0, segment.getLabelDisplayLevel());
+        assertEquals(0, segment.getAttachmentLevel());
+        assertEquals(0, segment.getLabelLocationRow());
+        assertEquals(0, segment.getLabelLocationColumn());
+        assertEquals(0, segment.getLabelCellHeight());
+        assertEquals(0, segment.getLabelCellWidth());
+    }
+}


### PR DESCRIPTION
Unlikely to be used since its a NITF 2.0 feature, but there isn't any other way to create a label segment.

Also fixes a comment in the ImageSegmentFactory that I noted during this work.