### PR TITLE
[IMG-188] Avoid embedding shared test resource in CGM and Render.

### DIFF
--- a/cgm/pom.xml
+++ b/cgm/pom.xml
@@ -103,6 +103,7 @@
                     <resourceBundles>
                         <resourceBundle>org.codice.imaging.nitf:codice-imaging-nitf-shared-test-resources:${project.version}</resourceBundle>
                     </resourceBundles>
+                    <attachToMain>false</attachToMain>
                     <outputBuildDirectory>${project.build.directory}/src/test/resources</outputBuildDirectory>
                 </configuration>
                 <executions>

--- a/fluent-api/pom.xml
+++ b/fluent-api/pom.xml
@@ -95,6 +95,27 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-remote-resources-plugin</artifactId>
+                <version>1.5</version>
+                <configuration>
+                    <resourceBundles>
+                        <resourceBundle>org.codice.imaging.nitf:codice-imaging-nitf-shared-test-resources:${project.version}</resourceBundle>
+                    </resourceBundles>
+                    <attachToMain>false</attachToMain>
+                    <outputBuildDirectory>${project.build.directory}/src/test/resources</outputBuildDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
     

--- a/render/pom.xml
+++ b/render/pom.xml
@@ -45,6 +45,7 @@
                     <resourceBundles>
                         <resourceBundle>org.codice.imaging.nitf:codice-imaging-nitf-shared-test-resources:${project.version}</resourceBundle>
                     </resourceBundles>
+                    <attachToMain>false</attachToMain>
                     <outputBuildDirectory>${project.build.directory}/src/test/resources</outputBuildDirectory>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Also need to use shared test resources for Fluent API, since its no longer embedded.