### PR TITLE
IMG-191 FileBackedHeapStrategy doesn't release all file handles on cl…

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/FileBackedHeapStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/FileBackedHeapStrategy.java
@@ -39,6 +39,8 @@ public class FileBackedHeapStrategy<R> implements HeapStrategy<R> {
 
     private File dataFile;
 
+    private RandomAccessFile randomAccessFile;
+
     /**
      * @param resultConverter a function that converts a RandomAccessFile to &lt;R&gt;
      */
@@ -64,7 +66,7 @@ public class FileBackedHeapStrategy<R> implements HeapStrategy<R> {
 
         try (FileOutputStream fos = new FileOutputStream(dataFile)) {
             fos.write(bytes);
-            RandomAccessFile randomAccessFile = new RandomAccessFile(dataFile, "rwd");
+            this.randomAccessFile = new RandomAccessFile(dataFile, "rwd");
             R result = resultConversionFunction.apply(randomAccessFile);
             return result;
         } catch (IOException e) {
@@ -76,6 +78,7 @@ public class FileBackedHeapStrategy<R> implements HeapStrategy<R> {
     public final void cleanUp() {
         if (dataFile != null) {
             try {
+                randomAccessFile.close();
                 Files.deleteIfExists(dataFile.toPath());
             } catch (IOException e) {
                 LOGGER.warn("Unable to delete file.", e);


### PR DESCRIPTION
…eanUp().

This change closes a RandomAccessFile that is used in the handleSegment() method. This
object wasn't being closed correctly which prevented the temporary file from being removed on certain Windows systems. The call to RandomAccessFile.close() has been moved into the cleanup() method.

@bradh 
@kcwire 