### PR TITLE
IMG-193: Change PIAIMC.MEANGSD to real data type.

### DIFF
--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -711,7 +711,7 @@
         <field name="GENERATION" length="1" type="integer"/>
         <field name="ESD" length="1" type="string"/>
         <field name="OTHERCOND" length="2" type="string"/>
-        <field name="MEANGSD" length="7" type="integer"/>
+        <field name="MEANGSD" length="7" type="real"/>
         <field name="IDATUM" length="3" type="string"/>
         <field name="IELLIP" length="3" type="string"/>
         <field name="PREPROC" length="2" type="string"/>


### PR DESCRIPTION
Updated the PIAIMC.MEANGSD to be "real" data type instead of integer in order to match with the spec valid values.

Reviewers:
@bradh 
@glenhein 