### PR TITLE
[IMG-194]: Fixed the RGB image handler to handle 16 bitsPerPixelPerBand for uncompressed images.

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/AbstractRgbImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/AbstractRgbImageRepresentationHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.render.imagerep;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.io.IOException;
+import java.util.Map;
+
+import javax.imageio.stream.ImageInputStream;
+
+import org.codice.imaging.nitf.render.ImageMask;
+
+abstract class AbstractRgbImageRepresentationHandler implements ImageRepresentationHandler {
+    protected final Map<Integer, Integer> bandMapping;
+
+    protected final int numOfReadsPerBand;
+
+    protected final int bitsToDiscard;
+
+    protected static final int ALPHA_MASK = 0xFF000000;
+
+    AbstractRgbImageRepresentationHandler(final Map<Integer, Integer> bandMap,
+            final int actualBitsPerPixelPerBand) {
+        this.bandMapping = bandMap;
+        this.numOfReadsPerBand = (int) Math.ceil(actualBitsPerPixelPerBand / ((double) Byte.SIZE));
+        if (actualBitsPerPixelPerBand - Byte.SIZE < 0) {
+            this.bitsToDiscard = 0;
+        } else {
+            this.bitsToDiscard = actualBitsPerPixelPerBand - Byte.SIZE;
+        }
+    }
+
+    @Override
+    public abstract void renderPixelBand(final DataBuffer data, final int pixelIndex,
+            final ImageInputStream imageInputStream, final int bandIndex) throws IOException;
+
+    @Override
+    public final BufferedImage createBufferedImage(final int blockWidth, final int blockHeight) {
+        return new BufferedImage(blockWidth, blockHeight, BufferedImage.TYPE_INT_ARGB);
+    }
+
+    @Override
+    public final void renderPadPixel(final ImageMask imageMask, final DataBuffer data, final int pixelIndex) {
+        if (imageMask.isPadPixel(data.getElem(pixelIndex))) {
+            data.setElem(pixelIndex, 0x00000000);
+        }
+    }
+}

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -60,16 +60,22 @@ public final class ImageRepresentationHandlerFactory {
     }
 
     private static ImageRepresentationHandler getRgbImageRepresentationHandler(final ImageSegment segment) {
-        if (segment.getNumberOfBitsPerPixelPerBand() != Byte.SIZE && segment.getNumberOfBitsPerPixelPerBand() != Short.SIZE) {
-            // It can be 8, 16 or 32 once we are at CLEVEL 6, but so far we can only do 16.
+        Map<Integer, Integer> bandMapping;
+        switch (segment.getNumberOfBitsPerPixelPerBand()) {
+        case Byte.SIZE:
+            bandMapping = getRgbImageRepresentationMapping(segment);
+            return new Rgb24ImageRepresentationHandler(bandMapping, segment.getActualBitsPerPixelPerBand());
+        case Short.SIZE:
+            bandMapping = getRgbImageRepresentationMapping(segment);
+            return new Rgb48ImageRepresentationHandler(bandMapping, segment.getActualBitsPerPixelPerBand());
+        default:
+            // It can be 8, 16 or 32 once we are at CLEVEL 6, but so far we can only do 8 or 16.
             // TODO: implement 32 bit support [IMG-113]
             return null;
         }
-        Map<Integer, Integer> bandMapping = getRgb24ImageRepresentationMapping(segment);
-        return new Rgb24ImageRepresentationHandler(bandMapping, segment.getActualBitsPerPixelPerBand());
     }
 
-    private static Map<Integer, Integer> getRgb24ImageRepresentationMapping(final ImageSegment imageSegment) {
+    private static Map<Integer, Integer> getRgbImageRepresentationMapping(final ImageSegment imageSegment) {
         Map<Integer, Integer> mapping = new HashMap<>();
         for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
             int leftShift;

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -60,14 +60,14 @@ public final class ImageRepresentationHandlerFactory {
     }
 
     private static ImageRepresentationHandler getRgbImageRepresentationHandler(final ImageSegment segment) {
-        if (segment.getNumberOfBitsPerPixelPerBand() != Byte.SIZE) {
+        if (segment.getNumberOfBitsPerPixelPerBand() != Byte.SIZE && segment.getNumberOfBitsPerPixelPerBand() != Short.SIZE) {
             // It can be 8, 16 or 32 once we are at CLEVEL 6, but so far we can only do 8 (enough for CLEVEL 3 and 5)
             // TODO: implement 16 bit support [IMG-112]
             // TODO: implement 32 bit support [IMG-113]
             return null;
         }
         Map<Integer, Integer> bandMapping = getRgb24ImageRepresentationMapping(segment);
-        return new Rgb24ImageRepresentationHandler(bandMapping);
+        return new Rgb24ImageRepresentationHandler(bandMapping, segment.getActualBitsPerPixelPerBand());
     }
 
     private static Map<Integer, Integer> getRgb24ImageRepresentationMapping(final ImageSegment imageSegment) {

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/ImageRepresentationHandlerFactory.java
@@ -61,8 +61,7 @@ public final class ImageRepresentationHandlerFactory {
 
     private static ImageRepresentationHandler getRgbImageRepresentationHandler(final ImageSegment segment) {
         if (segment.getNumberOfBitsPerPixelPerBand() != Byte.SIZE && segment.getNumberOfBitsPerPixelPerBand() != Short.SIZE) {
-            // It can be 8, 16 or 32 once we are at CLEVEL 6, but so far we can only do 8 (enough for CLEVEL 3 and 5)
-            // TODO: implement 16 bit support [IMG-112]
+            // It can be 8, 16 or 32 once we are at CLEVEL 6, but so far we can only do 16.
             // TODO: implement 32 bit support [IMG-113]
             return null;
         }

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagerep/Rgb48ImageRepresentationHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagerep/Rgb48ImageRepresentationHandler.java
@@ -20,18 +20,22 @@ import java.util.Map;
 
 import javax.imageio.stream.ImageInputStream;
 
-class Rgb24ImageRepresentationHandler extends AbstractRgbImageRepresentationHandler {
-
-    Rgb24ImageRepresentationHandler(final Map<Integer, Integer> bandMap,
+class Rgb48ImageRepresentationHandler extends AbstractRgbImageRepresentationHandler {
+    Rgb48ImageRepresentationHandler(final Map<Integer, Integer> bandMap,
             final int actualBitsPerPixelPerBand) {
         super(bandMap, actualBitsPerPixelPerBand);
     }
 
     @Override
-    public final void renderPixelBand(final DataBuffer data, final int pixelIndex,
-            final ImageInputStream imageInputStream, final int bandIndex) throws IOException {
+    public final void renderPixelBand(final DataBuffer data, final int pixelIndex, final ImageInputStream imageInputStream,
+            final int bandIndex) throws IOException {
+        int pixelBandValue = (imageInputStream.read() << Byte.SIZE) | (imageInputStream.read());
+
+        //Convert the value down to 8 bits.
+        pixelBandValue = pixelBandValue >> bitsToDiscard;
 
         data.setElem(pixelIndex,
-                ALPHA_MASK | data.getElem(pixelIndex) | (imageInputStream.read() << bandMapping.get(bandIndex)));
+                ALPHA_MASK | data.getElem(pixelIndex) | (pixelBandValue
+                        << bandMapping.get(bandIndex)));
     }
 }


### PR DESCRIPTION
This fixes the pixel renderer to handle more than 8 bits per pixel per band. Exceptions were being thrown by particular uncompressed images and not being handled correctly.

Reviewers:
@dcruver @bradh 