### PR TITLE
IMG-204 add setComplexityLevel to NitfHeader

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/header/NitfHeader.java
@@ -141,6 +141,14 @@ public interface NitfHeader extends TaggedRecordExtensionHandler {
     int getUserDefinedHeaderOverflow();
 
     /**
+     * Set the complexity level (CLEVEL) for the file. This should not be done arbitrarily - it
+     * needs to match the reality of the file properties, including all images. See MIL-STD-2500C
+     * Table A-10 for NITF 2.1 and NSIF 1.0 files.
+     * @param complexityLevel the complexity level
+     */
+    void setComplexityLevel(int complexityLevel);
+
+    /**
      * Set the title (FTITLE) for the file.
      *
      * The file title is 80 characters maximum.


### PR DESCRIPTION

Add a setComplexityLevel to NitfHeader so that the default value of "3" can be overridden when writing a NITF. NitfHeaderImpl already has the method, so this is just an addition to the interface.

Reviewers:

@bradh 
@dcruver 
@kcwire 

https://codice.atlassian.net/browse/IMG-204


