### PR TITLE
IMG-197 Parser fails completely when on NumberFormatException caused …

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/TreCollectionParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/TreCollectionParser.java
@@ -52,7 +52,12 @@ public class TreCollectionParser {
             bytesRead += TAG_LENGTH;
             int fieldLength = reader.readBytesAsInteger(TAGLEN_LENGTH);
             bytesRead += TAGLEN_LENGTH;
-            treCollection.add(treParser.parseOneTre(reader, tag, fieldLength, sourceSegment));
+            Tre tre = treParser.parseOneTre(reader, tag, fieldLength, sourceSegment);
+
+            if (tre != null) {
+                treCollection.add(tre);
+            }
+
             bytesRead += fieldLength;
         }
         return treCollection;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/TreCollectionTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/TreCollectionTest.java
@@ -15,13 +15,31 @@
 package org.codice.imaging.nitf.core.tre;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.NitfInputStreamReader;
+import org.codice.imaging.nitf.core.common.NitfReader;
 import org.junit.Test;
+
+import uk.org.lidalia.slf4jtest.LoggingEvent;
+import uk.org.lidalia.slf4jtest.TestLogger;
+import uk.org.lidalia.slf4jtest.TestLoggerFactory;
+import uk.org.lidalia.slf4jext.Level;
 
 /**
  * Tests for TreCollection class.
  */
 public class TreCollectionTest {
+
+    private static final TestLogger LOGGER = TestLoggerFactory.getTestLogger(TreParser.class);
 
     public TreCollectionTest() {
     }
@@ -50,5 +68,35 @@ public class TreCollectionTest {
         assertEquals(0, collection.getTREsWithName("One").size());
         assertEquals(1, collection.getTREsWithName("Two").size());
         assertEquals(tre2, collection.getTREs().get(0));
+    }
+
+    @Test
+    public void testGracefulRecovery() throws NitfFormatException {
+        LOGGER.clear();
+        String treString = "ENGRDA00058LAIR                00113majorVersion00010001A1NA00000002AENGRDA00058LAIR                00112majorVersion00010001A1NA000000011";
+        InputStream inputStream = new ByteArrayInputStream(treString.getBytes(StandardCharsets.ISO_8859_1));
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(inputStream);
+        NitfReader nitfReader = new NitfInputStreamReader(bufferedInputStream);
+        TreCollectionParser treCollectionParser = new TreCollectionParser();
+        TreCollection treCollection = treCollectionParser.parse(nitfReader, 138, TreSource.ImageExtendedSubheaderData);
+        assertEquals(2, treCollection.getTREs().size());
+
+        Tre tre0 = treCollection.getTREs().get(0);
+        assertNotNull(tre0.getName());
+        assertEquals(0, tre0.getEntries().size());
+        assertNotNull(tre0.getRawData());
+
+        Tre tre1 = treCollection.getTREs().get(1);
+        assertNotNull(tre1.getName());
+        assertEquals(3, tre1.getEntries().size());
+        assertNull(tre1.getRawData());
+        com.google.common.collect.ImmutableList<LoggingEvent> loggingEvents = LOGGER.getLoggingEvents();
+        assertEquals(2, loggingEvents.size());
+        assertEquals(Level.WARN, loggingEvents.get(0).getLevel());
+        assertEquals("Failed to parse TRE {}. See debug log for exception information.", loggingEvents.get(0).getMessage());
+        assertEquals(1, loggingEvents.get(0).getArguments().size());
+        assertEquals("ENGRDA", loggingEvents.get(0).getArguments().get(0));
+        assertEquals(Level.DEBUG, loggingEvents.get(1).getLevel());
+        assertEquals(NumberFormatException.class, loggingEvents.get(1).getThrowable().get().getClass());
     }
 }

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
@@ -40,13 +40,13 @@ public class MTIMSA_WrapTest extends SharedTreTestSupport {
     @Test
     public void basicParse() throws IOException, NitfFormatException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        baos.write("MTIMSA0016000199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e840000030045.0000000E+0100000000620160716215756.012345678".getBytes(StandardCharsets.ISO_8859_1));
+        baos.write("MTIMSA0015300199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e840000030045.0000000E+0100000000620160716215756.012345678".getBytes(StandardCharsets.ISO_8859_1));
         baos.write(parseHexBinary("0000000001312D00"));
         baos.write(parseHexBinary("01"));
         baos.write(parseHexBinary("01020304"));
         baos.write(parseHexBinary("00000001"));
         baos.write(parseHexBinary("4e"));
-        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 171, "MTIMSA");
+        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 164, "MTIMSA");
         MTIMSA mtimsa = new MTIMSA(tre);
         assertTrue(mtimsa.getValidity().isValid());
         assertEquals(1, mtimsa.getImageSegmentIndex());
@@ -72,7 +72,7 @@ public class MTIMSA_WrapTest extends SharedTreTestSupport {
     @Test
     public void basicNaNAltData() throws IOException, NitfFormatException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        baos.write("MTIMSA0016000199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e84000003004NaN                   20160716215756.012345678".getBytes(StandardCharsets.ISO_8859_1));
+        baos.write("MTIMSA0016100199fa238862-73ed-41fc-8d52-bfc7a954428c00295cb5511-7350-479b-9c8a-f028aba01e84000003004NaN                   20160716215756.012345678".getBytes(StandardCharsets.ISO_8859_1));
         baos.write(parseHexBinary("0000000001312D00"));
         baos.write(parseHexBinary("03"));
         baos.write(parseHexBinary("01020304"));
@@ -81,7 +81,7 @@ public class MTIMSA_WrapTest extends SharedTreTestSupport {
         baos.write(parseHexBinary("fe0245"));
 
         baos.write(parseHexBinary("3e0245"));
-        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 171, "MTIMSA");
+        Tre tre = parseTRE(new ByteArrayInputStream(baos.toByteArray()), 172, "MTIMSA");
         MTIMSA mtimsa = new MTIMSA(tre);
         assertFalse(mtimsa.getValidity().isValid());
         assertEquals(-1.0, mtimsa.getNominalFrameRate(), 0.00001);


### PR DESCRIPTION
…by bad TRE data.

This change modifies how the TREs are parsed so that an exception during parsing of any one TRE
won't cause parsing to stop. It relies on the TRE tag and length fields to be accurate. Given the
length of the TRE, it reads the appropriate number of bytes and creates a new NitfReader from
that. If parsing the TRE fails for any reason, then the outer NitfReader should be able to
continue normally, since the stream pointer will still be in the correct position.

This showed an error in two tests, which are also fixed as part of this commit.