### PR TITLE
IMG-206: Update NitfInputStream to handle partial reads of streams

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/common/NitfInputStreamReader.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/NitfInputStreamReader.java
@@ -87,12 +87,14 @@ public class NitfInputStreamReader extends SharedReader implements NitfReader {
     public final byte[] readBytesRaw(final int count) throws NitfFormatException {
         try {
             byte[] bytes = new byte[count];
-            int thisRead = input.read(bytes, 0, count);
-            if (thisRead == -1) {
-                throw new NitfFormatException("End of file reading from NITF stream.", numBytesRead);
-            } else if (thisRead < count) {
-                throw new NitfFormatException(String.format("Short read while reading from NITF stream (%s/%s).", thisRead, count),
-                                         numBytesRead + thisRead);
+            int thisRead = 0;
+            while (thisRead != count) {
+                int read = input.read(bytes, thisRead, count - thisRead);
+                if (read == -1) {
+                    throw new NitfFormatException("End of file reading from NITF stream.",
+                            numBytesRead);
+                }
+                thisRead += read;
             }
             numBytesRead += thisRead;
             return bytes;

--- a/core/src/test/java/org/codice/imaging/nitf/core/common/NitfInputStreamReaderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/common/NitfInputStreamReaderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+/**
+ * Tests for NitfInputStreamReader class
+ */
+public class NitfInputStreamReaderTest {
+
+    @Test
+    public void testSuccessPartialRead() throws IOException, NitfFormatException {
+        InputStream mockInputStream = mock(InputStream.class);
+        when(mockInputStream.read(new byte[anyInt()], anyInt(), anyInt())).thenReturn(30)
+                .thenReturn(70);
+
+        NitfReader reader = new NitfInputStreamReader(mockInputStream);
+        byte[] result = reader.readBytesRaw(100);
+
+        assertThat(result, is(new byte[100]));
+    }
+
+    @Test(expected = NitfFormatException.class)
+    public void testEndOfFileException() throws IOException, NitfFormatException {
+        InputStream mockInputStream = mock(InputStream.class);
+        when(mockInputStream.read(new byte[anyInt()], anyInt(), anyInt())).thenReturn(30)
+                .thenReturn(-1);
+
+        NitfReader reader = new NitfInputStreamReader(mockInputStream);
+        reader.readBytes(100);
+    }
+}


### PR DESCRIPTION
It is possible for the NitfInputStreamReader to ask for all the bytes of an input stream, but only get back a partial amount an then throw a NitfFormatException. This happens where the stream content is still being written to and it is not all available to be read.

Ticket: https://codice.atlassian.net/browse/IMG-206

Reviewers:
@dcruver 
@bradh 