### PR TITLE
IMG-205 Render to original data model

### DIFF
--- a/imagecompare/src/main/java/org/codice/imaging/compare/Compare.java
+++ b/imagecompare/src/main/java/org/codice/imaging/compare/Compare.java
@@ -32,7 +32,38 @@ import java.awt.image.BufferedImage;
  */
 public final class Compare {
 
+    private static final int RGB_MASK = 0xFFFFFF;
+
     private Compare() {
+    }
+
+    /**
+     * Check whether two images are the same while only considering specific non-padded region and ignore alpha values.
+     *
+     * @param imageUnderTest the image to check
+     * @param referenceImage the reference image
+     * @param nonPadWidth    the width to consider for comparison
+     * @param nonPadHeight   the height to consider for comparison
+     * @return true if the images are identical in size and content.
+     */
+    public static boolean areIdentical(final BufferedImage imageUnderTest,
+            final BufferedImage referenceImage, final int nonPadWidth, final int nonPadHeight) {
+        if (imageUnderTest.getWidth() != referenceImage.getWidth()) {
+            return false;
+        }
+        if (imageUnderTest.getHeight() != referenceImage.getHeight()) {
+            return false;
+        }
+        for (int x = 0; x < nonPadWidth; ++x) {
+            for (int y = 0; y < nonPadHeight; ++y) {
+                int iutPixel = imageUnderTest.getRGB(x, y);
+                int refPixel = referenceImage.getRGB(x, y);
+                if (iutPixel != refPixel && ((iutPixel & RGB_MASK) != (refPixel & RGB_MASK))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     /**

--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -14,8 +14,8 @@
  */
 package org.codice.imaging.nitf.render;
 
-import java.awt.Rectangle;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,6 +32,8 @@ import org.codice.imaging.nitf.core.image.ImageRepresentation;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.codice.imaging.nitf.render.imagemode.ImageModeHandler;
 import org.codice.imaging.nitf.render.imagemode.ImageModeHandlerFactory;
+import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandler;
+import org.codice.imaging.nitf.render.imagerep.ImageRepresentationHandlerFactory;
 
 /**
  * Renderer for NITF files.
@@ -106,6 +108,28 @@ public class NitfRenderer {
                 imageSegment.getImageLocationRow()
                         + (int) imageSegment.getNumberOfRows(),
                 BufferedImage.TYPE_INT_ARGB);
+        Graphics2D targetGraphic = img.createGraphics();
+
+        render(imageSegment, targetGraphic);
+        return img;
+    }
+
+    /**
+     * Render the segment as a BufferedImage using a data model that matches the NITF data as close as possible.
+     *
+     * @param imageSegment the image segment header for the segment to be rendered
+     * @return rendered image
+     * @throws IOException if the source data could not be read from
+     */
+    public final BufferedImage renderToClosestDataModel(final ImageSegment imageSegment) throws IOException {
+        ImageRepresentationHandler handler =
+                ImageRepresentationHandlerFactory.forImageSegment(imageSegment);
+
+        BufferedImage img = handler.createBufferedImage(imageSegment.getImageLocationColumn()
+                        + (int) imageSegment.getNumberOfColumns(),
+                imageSegment.getImageLocationRow()
+                        + (int) imageSegment.getNumberOfRows());
+
         Graphics2D targetGraphic = img.createGraphics();
 
         render(imageSegment, targetGraphic);

--- a/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/imagemode/BandSequentialImageModeHandler.java
@@ -46,7 +46,7 @@ class BandSequentialImageModeHandler extends BaseImageModeHandler implements Ima
 
         ImageBlockMatrix matrix = new ImageBlockMatrix(imageSegment, ()
                 -> imageRepresentationHandler.createBufferedImage((int) imageSegment.getNumberOfPixelsPerBlockHorizontal(),
-                        (int) imageSegment.getNumberOfPixelsPerBlockVertical()));
+                (int) imageSegment.getNumberOfPixelsPerBlockVertical()));
 
         for (int bandIndex = 0; bandIndex < imageSegment.getNumBands(); bandIndex++) {
             final int index = bandIndex;

--- a/render/src/test/java/org/codice/imaging/nitf/render/RenderTestSupport.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/RenderTestSupport.java
@@ -14,12 +14,14 @@
  */
 package org.codice.imaging.nitf.render;
 
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Function;
 import javax.imageio.ImageIO;
-import junit.framework.TestCase;
-import static junit.framework.TestCase.assertTrue;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.codice.imaging.compare.Compare;
 import org.codice.imaging.nitf.core.SlottedParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
@@ -29,6 +31,8 @@ import org.codice.imaging.nitf.core.header.NitfParser;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
 
 /**
  * Shared code for rendering tests
@@ -52,6 +56,50 @@ public class RenderTestSupport extends TestCase {
     }
 
     protected void testOneFile(final String testfile, final String parentDirectory) throws IOException, NitfFormatException {
+        testOneFileRenderToAGRB(testfile, parentDirectory);
+        testOneFileRenderToClosestDataModel(testfile, parentDirectory);
+    }
+
+    protected void testOneFileRenderToAGRB(final String testfile, final String parentDirectory)
+            throws IOException, NitfFormatException {
+        testFile(testfile, parentDirectory, nitfRendererImageSegmentPair -> {
+            try {
+                return nitfRendererImageSegmentPair.getLeft()
+                        .render(nitfRendererImageSegmentPair.getRight());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }, Pair::getRight,
+                (actualImage, expectedImage, imageSegment) -> Compare.areIdentical(actualImage, expectedImage));
+    }
+
+    protected void testOneFileRenderToClosestDataModel(final String testfile,
+            final String parentDirectory) throws IOException, NitfFormatException {
+
+        testFile(testfile,
+                parentDirectory,
+                nitfRendererImageSegmentPair -> {
+                    try {
+                        return nitfRendererImageSegmentPair.getLeft()
+                                .renderToClosestDataModel(nitfRendererImageSegmentPair.getRight());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                imageSegmentBufferedImagePair -> convert2ARGB(imageSegmentBufferedImagePair.getLeft(),
+                        imageSegmentBufferedImagePair.getRight()),
+                (actualImage, expectedImage, imageSegment) -> Compare.areIdentical(actualImage, expectedImage, (int) imageSegment.getNumberOfColumns(),
+                        (int) imageSegment.getNumberOfRows()));
+    }
+
+    private interface CompareImage {
+        boolean compare(BufferedImage actualImage, BufferedImage expectedImage, ImageSegment imageSegment);
+    }
+
+    protected void testFile(final String testfile,
+            final String parentDirectory, Function<Pair<NitfRenderer, ImageSegment>, BufferedImage> supplier,
+            Function<Pair<ImageSegment, BufferedImage>, BufferedImage> function,
+            CompareImage compareImage) throws IOException, NitfFormatException {
         String inputFileName = "/" + parentDirectory + "/" + testfile;
         System.out.println("================================== Testing :" + inputFileName);
         assertNotNull("Test file missing: " + inputFileName, getClass().getResource(inputFileName));
@@ -61,16 +109,31 @@ public class RenderTestSupport extends TestCase {
         for (int i = 0; i < parseStrategy.getDataSource().getImageSegments().size(); ++i) {
             ImageSegment imageSegment = parseStrategy.getDataSource().getImageSegments().get(i);
             NitfRenderer renderer = new NitfRenderer();
-            BufferedImage img = renderer.render(imageSegment);
+
+            BufferedImage img = supplier.apply(new ImmutablePair<>(renderer, imageSegment));
+
+            img = function.apply(new ImmutablePair<>(imageSegment, img));
+
             // TODO: move to automated (perceptual?) comparison
             File targetPath = new File("target" + File.separator + testfile + "_" + i + ".png");
             ImageIO.write(img, "png", targetPath);
             String referencePath = "/" + parentDirectory + "/" + testfile + "_" + i + ".ref.png";
             if (getClass().getResource(referencePath) != null) {
                 BufferedImage refImage = ImageIO.read(getClass().getResourceAsStream(referencePath));
-                assertTrue(Compare.areIdentical(img, refImage));
+                assertTrue(compareImage.compare(img, refImage, imageSegment));
                 targetPath.delete();
             }
         }
     }
+
+    private BufferedImage convert2ARGB(ImageSegment imageSegment, BufferedImage bufferedImage) {
+        BufferedImage imgAGRB = new BufferedImage(
+                imageSegment.getImageLocationColumn() + (int) imageSegment.getNumberOfColumns(),
+                imageSegment.getImageLocationRow() + (int) imageSegment.getNumberOfRows(),
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D targetGraphic = imgAGRB.createGraphics();
+        targetGraphic.drawImage(bufferedImage, 0, 0, null);
+        return imgAGRB;
+    }
+
 }


### PR DESCRIPTION
Currently, NitfRenderer renders to a BufferedImage that is 32-bit AGRB. This change adds support for NITFs to be rendered to a BufferedImage with the same data model as the original. 

NB: The original code renders to an image that is transparent. The new code renders to an image with a transparency setting equal to the first image block that was decoded. It is unclear at this time which approach is technically correct according to the NITF spec. The ticket IMG-208 was created to research this issue.

Reviewers:

@bradh 
@dcruver 
@jlcsmith 
