### PR TITLE
IMG-207 Guarantee input stream will be closed to prevent resource leaks

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/SlottedParseStrategy.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/SlottedParseStrategy.java
@@ -320,7 +320,7 @@ public class SlottedParseStrategy implements ParseStrategy {
                 dataExtensionSegment.mergeTREs(overflowTres);
             } else if (!"STREAMING_FILE_HEADER".equals(dataExtensionSegment.getIdentifier().trim())) {
                 ImageInputStream iis = desHeapStrategy.handleSegment(reader, dataLength);
-                dataExtensionSegment.setData(iis);
+                dataExtensionSegment.setDataConsumer(c -> c.accept(iis));
             }
         }
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/AbstractSegmentWriter.java
@@ -14,10 +14,13 @@
  */
 package org.codice.imaging.nitf.core.common;
 
+import static org.codice.imaging.nitf.core.common.CommonConstants.STANDARD_DATE_TIME_LENGTH;
+
 import java.io.DataOutput;
 import java.io.IOException;
+
 import javax.imageio.stream.ImageInputStream;
-import static org.codice.imaging.nitf.core.common.CommonConstants.STANDARD_DATE_TIME_LENGTH;
+
 import org.codice.imaging.nitf.core.graphic.GraphicSegmentWriter;
 import org.codice.imaging.nitf.core.security.SecurityMetadata;
 import org.codice.imaging.nitf.core.security.SecurityMetadataWriter;
@@ -193,17 +196,20 @@ public abstract class AbstractSegmentWriter {
      * Write out the data for the segment.
      *
      * @param data the data to write.
-     * @throws IOException on write failure.
      */
-    public final void writeSegmentData(final ImageInputStream data) throws IOException {
-        if (data == null) {
-            return;
-        }
-        data.seek(0);
-        byte[] buffer = new byte[GraphicSegmentWriter.BUFFER_SIZE];
-        int bytesRead;
-        while ((bytesRead = data.read(buffer)) != -1) {
-            mOutput.write(buffer, 0, bytesRead);
+    public final void writeSegmentData(final ImageInputStream data) {
+        try {
+            if (data == null) {
+                return;
+            }
+            data.seek(0);
+            byte[] buffer = new byte[GraphicSegmentWriter.BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = data.read(buffer)) != -1) {
+                mOutput.write(buffer, 0, bytesRead);
+            }
+        } catch (IOException ioe) {
+            LOG.warn(ioe.getMessage(), ioe);
         }
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegment.java
@@ -14,6 +14,8 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
+import java.util.function.Consumer;
+
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.common.CommonSegment;
 import org.codice.imaging.nitf.core.tre.TreCollection;
@@ -159,20 +161,6 @@ public interface DataExtensionSegment extends CommonSegment {
     boolean isStreamingMode();
 
     /**
-     * Set the DES data, if any.
-     *
-     * @param stream stream containing the data for this DES.
-     */
-    void setData(final ImageInputStream stream);
-
-    /**
-     * Get the data for this DES.
-     *
-     * @return data for this DES.
-     */
-    ImageInputStream getData();
-
-    /**
      * Get the length of the data for this segment.
      *
      * @return the number of bytes of data for this segment.
@@ -186,5 +174,18 @@ public interface DataExtensionSegment extends CommonSegment {
      */
     void setDataLength(final long length);
 
+    /**
+     * Performs an operation. Supplies a callback consumer to be called at the
+     * end of the operation.
+     *
+     * @param callbackConsumer - consumer to be run after operation is finished.
+     *
+     */
+    void consume(Consumer<ImageInputStream> callbackConsumer);
 
+    /**
+     * Set the DES data consumer.
+     * @param dataConsumer - the data consumer for this segment.
+     */
+    void setDataConsumer(Consumer<Consumer<ImageInputStream>> dataConsumer);
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentFactory.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentFactory.java
@@ -14,7 +14,6 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
-import java.io.IOException;
 import org.codice.imaging.nitf.core.common.FileType;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.security.SecurityMetadataFactory;
@@ -60,12 +59,8 @@ public final class DataExtensionSegmentFactory {
         des.setIdentifier(userDES.getTypeIdentifier());
         des.setDESVersion(userDES.getVersion());
         des.setUserDefinedSubheaderField(userDES.getUserDefinedSubheader());
-        des.setData(userDES.getUserData());
-        try {
-            des.setDataLength(userDES.getUserData().length());
-        } catch (IOException ex) {
-            throw new NitfFormatException("Cannot get data length: " + ex.getMessage());
-        }
+        des.setDataLength(userDES.getLength());
+        des.setDataConsumer(userDES.getUserDataConsumer());
         return des;
     }
 

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentImpl.java
@@ -15,6 +15,8 @@
 package org.codice.imaging.nitf.core.dataextension;
 
 import java.io.IOException;
+import java.util.function.Consumer;
+
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.common.CommonSegmentImpl;
 import org.codice.imaging.nitf.core.common.FileType;
@@ -36,8 +38,8 @@ class DataExtensionSegmentImpl extends CommonSegmentImpl implements DataExtensio
     private String overflowedHeaderType = null;
     private int desItemOverflowed = 0;
     private String userDefinedSubheaderField = null;
-    private ImageInputStream desData = null;
     private long dataLength = 0;
+    private Consumer<Consumer<ImageInputStream>> dataConsumer;
 
     /**
         Default constructor.
@@ -191,16 +193,18 @@ class DataExtensionSegmentImpl extends CommonSegmentImpl implements DataExtensio
      * {@inheritDoc}
      */
     @Override
-    public void setData(final ImageInputStream dataStream) {
-        desData = dataStream;
+    public void consume(final Consumer<ImageInputStream> consumer) {
+       if (dataConsumer != null) {
+           dataConsumer.accept(consumer);
+       }
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ImageInputStream getData() {
-        return desData;
+    public void setDataConsumer(final Consumer<Consumer<ImageInputStream>> consumer) {
+        dataConsumer = consumer;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/DataExtensionSegmentWriter.java
@@ -65,8 +65,6 @@ public class DataExtensionSegmentWriter extends AbstractSegmentWriter {
             byte[] treData = mTreParser.getTREs(des, TreSource.TreOverflowDES);
             mOutput.write(treData);
         }
-        if (des.getData() != null) {
-            writeSegmentData(des.getData());
-        }
+        des.consume(this::writeSegmentData);
     }
 }

--- a/core/src/main/java/org/codice/imaging/nitf/core/dataextension/UserDefinedDataExtensionSegment.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/dataextension/UserDefinedDataExtensionSegment.java
@@ -14,6 +14,8 @@
  */
 package org.codice.imaging.nitf.core.dataextension;
 
+import java.util.function.Consumer;
+
 import javax.imageio.stream.ImageInputStream;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 
@@ -68,7 +70,8 @@ public interface UserDefinedDataExtensionSegment {
     String getUserDefinedSubheader() throws NitfFormatException;
 
     /**
-     * Get the user defined data.
+     * Returns a consumer that gets user defined DES data. The consumer also
+     * contains a call back consumer to be called at the end of the operation.
      *
      * From MIL-STD-2500C: "DES User-Defined Data. This field shall contain data
      * of either binary or character types defined by and formatted according to
@@ -76,9 +79,15 @@ public interface UserDefinedDataExtensionSegment {
      * another NITF field length limits to be exceeded, but is otherwise fully
      * user-defined."
      *
-     * @return stream containing the user defined data.
-     * @throws NitfFormatException if there was a problem generating the data.
+     * @return Consumer to get the user-defined DES data.
      */
-    ImageInputStream getUserData() throws NitfFormatException;
+    Consumer<Consumer<ImageInputStream>> getUserDataConsumer();
+
+    /**
+     * Get the combined length of the user-defined DES files.
+     *
+     * @return the combined length of the user-defined DES files.
+     */
+    long getLength();
 
 }

--- a/deswrap/src/main/java/org/codice/imaging/nitf/deswrap/CSSHPA.java
+++ b/deswrap/src/main/java/org/codice/imaging/nitf/deswrap/CSSHPA.java
@@ -25,6 +25,9 @@ import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.dataextension.DataExtensionSegment;
 import static org.codice.imaging.nitf.core.dataextension.DataExtensionSegmentFactory.getUserDefinedDES;
 import org.codice.imaging.nitf.core.dataextension.UserDefinedDataExtensionSegment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.codice.imaging.nitf.deswrap.CSSHPAConstants.CC_SOURCE_LENGTH;
 import static org.codice.imaging.nitf.deswrap.CSSHPAConstants.CLOUD_SHAPES_USE;
 import static org.codice.imaging.nitf.deswrap.CSSHPAConstants.FILEOFFSET_LENGTH;
@@ -50,6 +53,8 @@ public class CSSHPA extends DES {
     }
 
     private Map<String, ShapePart> mShapeParts = new HashMap<>();
+
+    private static final Logger LOG = LoggerFactory.getLogger(CSSHPA.class);
 
     /**
      * Create a Shapefile data extension segment (CSSHPA DES).
@@ -216,8 +221,14 @@ public class CSSHPA extends DES {
         ShapePart shapePart = mShapeParts.get(filename);
         int length = (int) (shapePart.endOffset - shapePart.startOffset);
         byte[] data = new byte[length];
-        mDES.getData().seek(shapePart.startOffset);
-        mDES.getData().readFully(data);
+        mDES.consume(imageInputStream -> {
+            try {
+                imageInputStream.seek(shapePart.startOffset);
+                imageInputStream.readFully(data);
+            } catch (IOException ieo) {
+                LOG.warn(ieo.getMessage(), ieo);
+            }
+        });
         return data;
     }
 


### PR DESCRIPTION
Previously a FileImageOutputStream in CSSHPAUserDefinedDES: getUserData(), wasn't getting closed after being used. This PR will guarantee that the stream will always get closed after it's use. Also, the temp file that gets created as an input to the stream will get deleted at the same time the stream closes.

@dcruver 
@bradh 