### PR TITLE
Fixed miscalculation in rendering of masked jpeg images. If the numbe…

### DIFF
--- a/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
+++ b/render/src/main/java/org/codice/imaging/nitf/render/NitfRenderer.java
@@ -163,7 +163,7 @@ public class NitfRenderer {
             }
 
             BufferedImage img = reader.read(
-                    (columnIndex + rowIndex * imageSegment.getNumberOfBlocksPerColumn()) - maskedBlocks.get());
+                    (columnIndex + rowIndex * imageSegment.getNumberOfBlocksPerRow()) - maskedBlocks.get());
 
             targetGraphic.drawImage(img,
                     columnIndex * (int) imageSegment.getNumberOfPixelsPerBlockHorizontal(),


### PR DESCRIPTION
…r of blocks per row did not match the number of blocks per column, the image would fail to render.