### PR TITLE
[IMG-209] Update coverage requirements to reflect actuals.

### DIFF
--- a/trewrap/pom.xml
+++ b/trewrap/pom.xml
@@ -48,22 +48,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.9</minimum>
+                                            <minimum>0.95</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.9</minimum>
+                                            <minimum>0.91</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.9</minimum>
+                                            <minimum>0.99</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>


### PR DESCRIPTION
A previous commit (https://github.com/codice/imaging-nitf/commit/582391a04c40bf78fcecd32833a48914ad11cdfd) partly addressed the coverage in TRE wrappers.

I had more ambitious plans to mock up a failing exception, but it defeated me.

This seems enough for now.