### PR TITLE
[IMG-224] Implement check for oversize TREs on write.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
@@ -57,6 +57,21 @@ public class TreParser {
 
     private static final String TRE_XML_LOAD_ERROR_MESSAGE = "Exception while loading TRE XML";
 
+    // If this isn't obvious, the max len is 99999, but first 3 are for the
+    // overflow DES index, if any.
+    private static final int MAX_HEADER_DATA_LEN = 99996;
+    // The others have lower limits - see specs.
+    // 9747 minus 3
+    private static final int MAX_LABEL_DATA_LEN = 9744;
+    // 8833 minus 3
+    private static final int MAX_SYMBOL_DATA_LEN = 8830;
+    // 9741 minus 3
+    private static final int MAX_GRAPHIC_DATA_LEN = 9738;
+    // 9717 minus 3
+    private static final int MAX_TEXT_DATA_LEN = 9714;
+    // We seem unlikely to hit this: 10^9 - 2
+    private static final int MAX_DES_DATA_LEN = 999999998;
+
     private static Tres tresStructure = null;
 
     /**
@@ -351,6 +366,9 @@ public class TreParser {
                 baos.write(treData);
             }
         }
+        if (baos.size() > getValidSizeForTreSource(source)) {
+            throw new NitfFormatException("TREs exceed valid limit for source");
+        }
         return baos.toByteArray();
     }
 
@@ -593,6 +611,34 @@ public class TreParser {
             }
         }
     }
+
+    /**
+     * Get the largest valid size of all TREs for the specified location.
+     * @param source the location of the TREs.
+     * @return valid size in bytes.
+     */
+    public static final int getValidSizeForTreSource(final TreSource source) {
+        switch (source) {
+            case UserDefinedHeaderData:
+            case ExtendedHeaderData:
+            case UserDefinedImageData:
+            case ImageExtendedSubheaderData:
+                return MAX_HEADER_DATA_LEN;
+            case SymbolExtendedSubheaderData:
+                return MAX_SYMBOL_DATA_LEN;
+            case LabelExtendedSubheaderData:
+                return MAX_LABEL_DATA_LEN;
+            case GraphicExtendedSubheaderData:
+                return MAX_GRAPHIC_DATA_LEN;
+            case TextExtendedSubheaderData:
+                return MAX_TEXT_DATA_LEN;
+            case TreOverflowDES:
+                return MAX_DES_DATA_LEN;
+            default:
+                throw new IllegalStateException("Missing case for TreSource");
+        }
+    }
+
 
 
 }

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/TreParser_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/TreParser_Test.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ */
+package org.codice.imaging.nitf.core.tre.impl;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
+import javax.xml.transform.stream.StreamSource;
+import org.codice.imaging.nitf.core.common.NitfFormatException;
+import org.codice.imaging.nitf.core.common.TaggedRecordExtensionHandler;
+import org.codice.imaging.nitf.core.tre.Tre;
+import org.codice.imaging.nitf.core.tre.TreCollection;
+import org.codice.imaging.nitf.core.tre.TreSource;
+import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for TreParser.
+ */
+public class TreParser_Test {
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+    public TreParser_Test() {
+    }
+
+    @Test
+    public void checkSizeHeaderSegment() {
+        assertEquals(99999 - 3, TreParser.getValidSizeForTreSource(TreSource.ExtendedHeaderData));
+        assertEquals(99999 - 3, TreParser.getValidSizeForTreSource(TreSource.UserDefinedHeaderData));
+    }
+    
+    @Test
+    public void checkSizeImageSegment() {
+        assertEquals(99999 - 3, TreParser.getValidSizeForTreSource(TreSource.ImageExtendedSubheaderData));
+        assertEquals(99999 - 3, TreParser.getValidSizeForTreSource(TreSource.UserDefinedImageData));
+    }
+    
+    @Test
+    public void checkSizeSymbolSegment() {
+        assertEquals(8833 - 3, TreParser.getValidSizeForTreSource(TreSource.SymbolExtendedSubheaderData));
+    }
+    
+    @Test
+    public void checkSizeLabelSegment() {
+        assertEquals(9747 - 3, TreParser.getValidSizeForTreSource(TreSource.LabelExtendedSubheaderData));
+    }
+
+    @Test
+    public void checkSizeGraphicSegment() {
+        assertEquals(9741 - 3, TreParser.getValidSizeForTreSource(TreSource.GraphicExtendedSubheaderData));
+    }
+
+    @Test
+    public void checkSizeTextSegment() {
+        assertEquals(9717 - 3, TreParser.getValidSizeForTreSource(TreSource.TextExtendedSubheaderData));
+    }
+    
+    @Test
+    public void checkSizeOverflowSegment() {
+        assertEquals(999999998, TreParser.getValidSizeForTreSource(TreSource.TreOverflowDES));
+    }
+
+    private void assertCollectionCanBeSerialised(TreCollection collection, TreSource source, int expectedLen) throws NitfFormatException, IOException {
+        TreParser parser = new TreParser();
+        parser.registerAdditionalTREdescriptor(new StreamSource(new StringReader(xmlTREs)));
+        TaggedRecordExtensionHandler handler = mock(TaggedRecordExtensionHandler.class);
+        when(handler.getTREsRawStructure()).thenReturn(collection);
+        byte[] treData = parser.getTREs(handler, source);
+        assertEquals(expectedLen, treData.length);
+    }
+
+    private void assertCollectionCanNotBeSerialised(TreCollection collection, TreSource source) throws NitfFormatException, IOException {
+        TreParser parser = new TreParser();
+        parser.registerAdditionalTREdescriptor(new StreamSource(new StringReader(xmlTREs)));
+        TaggedRecordExtensionHandler handler = mock(TaggedRecordExtensionHandler.class);
+        when(handler.getTREsRawStructure()).thenReturn(collection);
+        exception.expect(NitfFormatException.class);
+        exception.expectMessage("TREs exceed valid limit for source");
+        parser.getTREs(handler, source);
+    }
+        
+    @Test
+    public void checkSingleSmallTREIsValid() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("One", TreSource.ExtendedHeaderData);
+        tre1.setRawData(new byte[1000]);
+        collection.add(tre1);
+        assertCollectionCanBeSerialised(collection, TreSource.ExtendedHeaderData, 1011);
+    }
+
+    private final String xmlTREs
+            = "<?xml version=\"1.0\"?>"
+            + " <tres>"
+            + "     <tre name=\"FILL\">"
+            + "         <field name=\"FILL_LEN\" type=\"integer\" length=\"5\"/>"
+            + "         <field name=\"FILL_DATA\" type=\"string\" length_var=\"FILL_LEN\"/>"
+            + "     </tre>"
+            + " </tres>";
+
+    @Test
+    public void checkSingleLargeTREIsValid() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.ExtendedHeaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "99980", "integer"));
+        char[] filldata = new char[99980];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanBeSerialised(collection, TreSource.ExtendedHeaderData, 99996);
+    }
+
+    @Test
+    public void checkSingleOversizeTREIsNotValid() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.ExtendedHeaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "99981", "integer"));
+        char[] filldata = new char[99981];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanNotBeSerialised(collection, TreSource.ExtendedHeaderData);
+    }
+    
+    @Test
+    public void checkSingleLargeTREIsValidInTextSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.TextExtendedSubheaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "9698", "integer"));
+        char[] filldata = new char[9698];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanBeSerialised(collection, TreSource.TextExtendedSubheaderData, 9714);
+    }
+    
+    @Test
+    public void checkSingleOversizeTREIsNotValidInTextSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.TextExtendedSubheaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "9699", "integer"));
+        char[] filldata = new char[9699];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanNotBeSerialised(collection, TreSource.TextExtendedSubheaderData);
+    }
+    
+    public void checkSingleLargeTREIsValidInImageSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.ImageExtendedSubheaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "99980", "integer"));
+        char[] filldata = new char[99980];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanBeSerialised(collection, TreSource.ImageExtendedSubheaderData, 99996);
+    }
+    
+    @Test
+    public void checkSingleOversizeTREIsNotValidInImageSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.ImageExtendedSubheaderData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "99981", "integer"));
+        char[] filldata = new char[99981];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        assertCollectionCanNotBeSerialised(collection, TreSource.ImageExtendedSubheaderData);
+    }
+    
+    public void checkMultipleLargeTREIsValidInImageSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.UserDefinedImageData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "90980", "integer"));
+        char[] filldata = new char[90980];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        Tre tre2 = TreFactory.getDefault("FILL", TreSource.UserDefinedImageData);
+        tre2.add(new TreEntryImpl("FILL_LEN", "9969", "integer"));
+        char[] filldata2 = new char[9969];
+        Arrays.fill(filldata2, 'X');
+        tre2.add((new TreEntryImpl("FILL_DATA", new String(filldata2), "string")));
+        collection.add(tre2);
+        assertCollectionCanBeSerialised(collection, TreSource.UserDefinedImageData, 99996);
+    }
+    
+    @Test
+    public void checkMultipleOversizeTREIsNotValidInImageSegment() throws NitfFormatException, IOException {
+        TreCollection collection = new TreCollectionImpl();
+        Tre tre1 = TreFactory.getDefault("FILL", TreSource.UserDefinedImageData);
+        tre1.add(new TreEntryImpl("FILL_LEN", "90980", "integer"));
+        char[] filldata = new char[90980];
+        Arrays.fill(filldata, 'X');
+        tre1.add((new TreEntryImpl("FILL_DATA", new String(filldata), "string")));
+        collection.add(tre1);
+        Tre tre2 = TreFactory.getDefault("FILL", TreSource.UserDefinedImageData);
+        tre2.add(new TreEntryImpl("FILL_LEN", "9970", "integer"));
+        char[] filldata2 = new char[9970];
+        Arrays.fill(filldata2, 'X');
+        tre2.add((new TreEntryImpl("FILL_DATA", new String(filldata2), "string")));
+        collection.add(tre2);
+        assertCollectionCanNotBeSerialised(collection, TreSource.UserDefinedImageData);
+    }
+}


### PR DESCRIPTION
Slightly revised approach - now throws instead of returning 0 for default case (which should not occur unless an item is added to the TreSource enumeration).