### PR TITLE
PIAPRD NITF SPEC Configuration Error

### DIFF
--- a/core/src/main/resources/nitf_spec.xml
+++ b/core/src/main/resources/nitf_spec.xml
@@ -810,7 +810,7 @@
         </loop>
     </tre>
 
-    <tre name="PIAPRD" minlength="201" maxlength="63759" location="image">
+    <tre name="PIAPRD" minlength="201" maxlength="63759" location="file">
         <field name="ACCESSID" length="64" type="string"/>
         <field name="FMCONTROL" length="32" type="string"/>
         <field name="SUBDET" length="1" type="string"/>


### PR DESCRIPTION
According to Harris' documentation (https://www.harrisgeospatial.com/docs/BackgroundPIATREs.html), PIAPRD header location should be in the file and not image. I updated the nitf spec configuration file to reflect its proper location. Further up in the spec it mentions PIAPRC should match PIAPRD, which is already defined in the file area too. 