### PR TITLE
[IMG-233] Additional Security changes to remove public constructors.

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilder20.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilder20.java
@@ -26,7 +26,7 @@ import java.util.function.Supplier;
  *
  * A simple example of its use is:
  * <pre>{@code
- *      FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+ *      FileSecurityMetadataBuilder20 builder = FileSecurityMetadataBuilder20.newInstance();
  *      builder.securityClassification(SecurityClassification.UNCLASSIFIED);
  *      FileSecurityMetadata securityMetadata = builder.get();
  * }</pre>
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
  * The API supports method chaining for a more fluent style, which is useful for
  * more involved metadata requirements:
  * <pre>{@code
- *      FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+ *      FileSecurityMetadataBuilder20 builder = FileSecurityMetadataBuilder20.newInstance();
  *      builder.securityClassification(SecurityClassification.RESTRICTED)
  *              .fileCopyNumber("00001")
  *              .codewords("AB CD")
@@ -52,25 +52,37 @@ public final class FileSecurityMetadataBuilder20
         extends FileSecurityMetadataBuilder<FileSecurityMetadataBuilder20, SecurityMetadataBuilder20>
         implements Supplier<FileSecurityMetadata> {
 
-
     /**
      * Constructor.
      */
-    public FileSecurityMetadataBuilder20() {
-        super.instance = this;
-        super.builderInstance = new SecurityMetadataBuilder20();
+    private FileSecurityMetadataBuilder20() {
     }
 
     /**
-     * Constructor.
+     * Constructor method.
+     *
+     * @return new instance of this FileSecurityMetadataBuilder20
+     */
+    public static FileSecurityMetadataBuilder20 newInstance() {
+        FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+        builder.instance = builder;
+        builder.builderInstance = SecurityMetadataBuilder20.newInstance();
+        return builder;
+    }
+
+    /**
+     * Copy constructor method.
      *
      * @param securityMetadata base security metadata.
+     * @return new instance of this FileSecurityMetadataBuilder20
      */
-    public FileSecurityMetadataBuilder20(final FileSecurityMetadata securityMetadata) {
-        super.instance = this;
-        builderInstance = new SecurityMetadataBuilder20(securityMetadata);
-        nitfFileCopyNumber = securityMetadata.getFileCopyNumber();
-        nitfFileNumberOfCopies = securityMetadata.getFileNumberOfCopies();
+    public static FileSecurityMetadataBuilder20 newInstance(final FileSecurityMetadata securityMetadata) {
+        FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+        builder.instance = builder;
+        builder.builderInstance = SecurityMetadataBuilder20.newInstance(securityMetadata);
+        builder.fileCopyNumber(securityMetadata.getFileCopyNumber());
+        builder.fileNumberOfCopies(securityMetadata.getFileNumberOfCopies());
+        return builder;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilder21.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilder21.java
@@ -26,7 +26,7 @@ import org.codice.imaging.nitf.core.common.FileType;
  *
  * A simple example of its use is:
  * <pre>{@code
- *      FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+ *      FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
  *      builder.securityClassification(SecurityClassification.UNCLASSIFIED);
  *      FileSecurityMetadata securityMetadata = builder.get();
  * }</pre>
@@ -34,7 +34,7 @@ import org.codice.imaging.nitf.core.common.FileType;
  * The API supports method chaining for a more fluent style, which is useful for
  * more involved metadata requirements:
  * <pre>{@code
- *      FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+ *      FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
  *      builder.securityClassification(SecurityClassification.RESTRICTED)
  *              .fileCopyNumber("00001")
  *              .securityClassificationSystem("AS")
@@ -60,26 +60,35 @@ public final class FileSecurityMetadataBuilder21
         extends FileSecurityMetadataBuilder<FileSecurityMetadataBuilder21, SecurityMetadataBuilder21>
         implements Supplier<FileSecurityMetadata> {
 
-    /**
-     * Constructor.
-     *
-     * @param fileType the type of file (NITF 2.1 or NSIF 1.0)
-     */
-    public FileSecurityMetadataBuilder21(final FileType fileType) {
-        super.instance = this;
-        builderInstance = new SecurityMetadataBuilder21(fileType);
+    private FileSecurityMetadataBuilder21() {
     }
 
     /**
-     * Constructor.
+     * Constructor method.
+     *
+     * @param fileType the type of file (NITF 2.1 or NSIF 1.0)
+     * @return new instance of this FileSecurityMetadataBuilder21
+     */
+    public static FileSecurityMetadataBuilder21 newInstance(final FileType fileType) {
+        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21();
+        builder.instance = builder;
+        builder.builderInstance = SecurityMetadataBuilder21.newInstance(fileType);
+        return builder;
+    }
+
+    /**
+     * Copy constructor method.
      *
      * @param securityMetadata base security metadata.
+     * @return new instance of this FileSecurityMetadataBuilder21
      */
-    public FileSecurityMetadataBuilder21(final FileSecurityMetadata securityMetadata) {
-        super.instance = this;
-        builderInstance = new SecurityMetadataBuilder21(securityMetadata);
-        nitfFileCopyNumber = securityMetadata.getFileCopyNumber();
-        nitfFileNumberOfCopies = securityMetadata.getFileNumberOfCopies();
+    public static FileSecurityMetadataBuilder21 newInstance(final FileSecurityMetadata securityMetadata) {
+        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21();
+        builder.instance = builder;
+        builder.builderInstance = SecurityMetadataBuilder21.newInstance(securityMetadata);
+        builder.fileCopyNumber(securityMetadata.getFileCopyNumber());
+        builder.fileNumberOfCopies(securityMetadata.getFileNumberOfCopies());
+        return builder;
     }
 
     /**

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilder20.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilder20.java
@@ -26,7 +26,7 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  *
  * A simple example of its use is:
  * <pre>{@code
- *      SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+ *      SecurityMetadataBuilder20 builder = SecurityMetadataBuilder20.newInstance();
  *      builder.securityClassification(SecurityClassification.UNCLASSIFIED);
  *      SecurityMetadata securityMetadata = builder.get();
  * }</pre>
@@ -34,36 +34,49 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  * The API supports method chaining for a more fluent style, which is useful for
  * more involved metadata requirements:
  * <pre>{@code
- *      SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+ *      SecurityMetadataBuilder20 builder = SecurityMetadataBuilder20.newInstance();
  *      builder.securityClassification(SecurityClassification.UNCLASSIFIED)
  *              .downgradeDateOrSpecialCase("999998")
  *              .downgradeEvent("When its good.");
  *      SecurityMetadata securityMetadata = builder.get();
  * }</pre>
  */
-public class SecurityMetadataBuilder20 extends SecurityMetadataBuilder<SecurityMetadataBuilder20> implements Supplier<SecurityMetadata> {
+public final class SecurityMetadataBuilder20 extends SecurityMetadataBuilder<SecurityMetadataBuilder20> implements Supplier<SecurityMetadata> {
 
     private String nitfDowngradeDateOrSpecialCase = null;
     private String nitfDowngradeEvent = null;
 
+    private SecurityMetadataBuilder20() {
+        super(FileType.NITF_TWO_ZERO);
+    }
+
+    private SecurityMetadataBuilder20(final SecurityMetadata securityMetadata) {
+        super(securityMetadata);
+    }
+
     /**
      * Constructor.
+     *
+     * @return new instance of a SecurityMetadataBuilder20
      */
-    public SecurityMetadataBuilder20() {
-        super(FileType.NITF_TWO_ZERO);
-        super.instance = this;
+    public static SecurityMetadataBuilder20 newInstance() {
+        SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+        builder.instance = builder;
+        return builder;
     }
 
     /**
      * Copy constructor.
      *
      * @param securityMetadata data to initialise from.
+     * @return new instance of a SecurityMetadataBuilder20
      */
-    public SecurityMetadataBuilder20(final SecurityMetadata securityMetadata) {
-        super(securityMetadata);
-        super.instance = this;
-        this.nitfDowngradeDateOrSpecialCase = securityMetadata.getDowngradeDateOrSpecialCase();
-        this.nitfDowngradeEvent = securityMetadata.getDowngradeEvent();
+    public static SecurityMetadataBuilder20 newInstance(final SecurityMetadata securityMetadata) {
+        SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20(securityMetadata);
+        builder.instance = builder;
+        builder.downgradeDateOrSpecialCase(securityMetadata.getDowngradeDateOrSpecialCase());
+        builder.downgradeEvent(securityMetadata.getDowngradeEvent());
+        return builder;
     }
 
     /**
@@ -82,7 +95,7 @@ public class SecurityMetadataBuilder20 extends SecurityMetadataBuilder<SecurityM
      * @param dateOrSpecialCase the date or special case
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder20 downgradeDateOrSpecialCase(final String dateOrSpecialCase) {
+    public SecurityMetadataBuilder20 downgradeDateOrSpecialCase(final String dateOrSpecialCase) {
         this.nitfDowngradeDateOrSpecialCase = dateOrSpecialCase;
         return this;
     }
@@ -98,13 +111,13 @@ public class SecurityMetadataBuilder20 extends SecurityMetadataBuilder<SecurityM
      * event applies
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder20 downgradeEvent(final String event) {
+    public SecurityMetadataBuilder20 downgradeEvent(final String event) {
         this.nitfDowngradeEvent = event;
         return this;
     }
 
     @Override
-    final void populateVersionSpecific(final SecurityMetadataImpl securityMetadata) {
+    void populateVersionSpecific(final SecurityMetadataImpl securityMetadata) {
         securityMetadata.setDowngradeEvent(nitfDowngradeEvent);
         securityMetadata.setDowngradeDateOrSpecialCase(nitfDowngradeDateOrSpecialCase);
     }

--- a/core/src/main/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilder21.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilder21.java
@@ -26,7 +26,7 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  *
  * A simple example of its use is:
  * <pre>{@code
- *      SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+ *      SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
  *      builder.securityClassification(SecurityClassification.UNCLASSIFIED);
  *      SecurityMetadata securityMetadata = builder.get();
  * }</pre>
@@ -34,7 +34,7 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  * The API supports method chaining for a more fluent style, which is useful for
  * more involved metadata requirements:
  * <pre>{@code
- *      SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+ *      SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
  *      builder.securityClassification(SecurityClassification.RESTRICTED)
  *              .securityClassificationSystem("AS")
  *              .downgrade("F")
@@ -54,7 +54,7 @@ import org.codice.imaging.nitf.core.security.SecurityMetadata;
  *      SecurityMetadata securityMetadata = builder.get();
  * }</pre>
  */
-public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityMetadataBuilder21> implements Supplier<SecurityMetadata> {
+public final class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityMetadataBuilder21> implements Supplier<SecurityMetadata> {
 
     private String securityClassificationSystem = "";
     private String classificationReason = "";
@@ -72,9 +72,21 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      *
      * @param fileType the type of NITF file to generate security metadata for
      */
-    public SecurityMetadataBuilder21(final FileType fileType) {
+    private SecurityMetadataBuilder21(final FileType fileType) {
         super(fileType);
-        super.instance = this;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param fileType the type of NITF file to generate security metadata for (NITF 2.1 or NSIF 1.0).
+     *
+     * @return new instance of this SecurityMetadataBuilder21
+     */
+    public static SecurityMetadataBuilder21 newInstance(final FileType fileType) {
+        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(fileType);
+        builder.instance = builder;
+        return builder;
     }
 
     /**
@@ -82,19 +94,30 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      *
      * @param securityMetadata data to initialise from.
      */
-    public SecurityMetadataBuilder21(final SecurityMetadata securityMetadata) {
+    private SecurityMetadataBuilder21(final SecurityMetadata securityMetadata) {
         super(securityMetadata);
-        nitfDeclassificationExemption = securityMetadata.getDeclassificationExemption();
-        nitfDeclassificationDate = securityMetadata.getDeclassificationDate();
-        nitfDeclassificationType = securityMetadata.getDeclassificationType();
-        securityClassificationSystem = securityMetadata.getSecurityClassificationSystem();
-        nitfDowngrade = securityMetadata.getDowngrade();
-        nitfDowngradeDate = securityMetadata.getDowngradeDate();
-        nitfSecuritySourceDate = securityMetadata.getSecuritySourceDate();
-        nitfClassificationAuthorityType = securityMetadata.getClassificationAuthorityType();
-        classificationReason = securityMetadata.getClassificationReason();
-        nitfClassificationText = securityMetadata.getClassificationText();
-        super.instance = this;
+    }
+
+    /**
+     * Copy constructor method.
+     *
+     * @param securityMetadata data to initialise from.
+     * @return new instance of this SecurityMetadataBuilder21
+     */
+    public static SecurityMetadataBuilder21 newInstance(final SecurityMetadata securityMetadata) {
+        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(securityMetadata);
+        builder.instance = builder;
+        builder.declassificationExemption(securityMetadata.getDeclassificationExemption());
+        builder.declassificationDate(securityMetadata.getDeclassificationDate());
+        builder.declassificationType(securityMetadata.getDeclassificationType());
+        builder.securityClassificationSystem(securityMetadata.getSecurityClassificationSystem());
+        builder.downgrade(securityMetadata.getDowngrade());
+        builder.downgradeDate(securityMetadata.getDowngradeDate());
+        builder.securitySourceDate(securityMetadata.getSecuritySourceDate());
+        builder.classificationAuthorityType(securityMetadata.getClassificationAuthorityType());
+        builder.classificationReason(securityMetadata.getClassificationReason());
+        builder.classificationText(securityMetadata.getClassificationText());
+        return builder;
     }
 
     /**
@@ -122,7 +145,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * character country code)
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 securityClassificationSystem(final String classificationSystem) {
+    public SecurityMetadataBuilder21 securityClassificationSystem(final String classificationSystem) {
         securityClassificationSystem = classificationSystem;
         return this;
     }
@@ -142,7 +165,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 classificationReason(final String reasonCode) {
+    public SecurityMetadataBuilder21 classificationReason(final String reasonCode) {
         classificationReason = reasonCode;
         return this;
     }
@@ -162,7 +185,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 securitySourceDate(final String securitySourceDate) {
+    public SecurityMetadataBuilder21 securitySourceDate(final String securitySourceDate) {
         nitfSecuritySourceDate = securitySourceDate;
         return this;
     }
@@ -185,7 +208,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * maximum), or an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 declassificationType(final String declassificationType) {
+    public SecurityMetadataBuilder21 declassificationType(final String declassificationType) {
         nitfDeclassificationType = declassificationType;
         return this;
     }
@@ -204,7 +227,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * or an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 declassificationDate(final String declassificationDate) {
+    public SecurityMetadataBuilder21 declassificationDate(final String declassificationDate) {
         nitfDeclassificationDate = declassificationDate;
         return this;
     }
@@ -229,7 +252,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * characters maximum), or an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 declassificationExemption(final String declassificationExemption) {
+    public SecurityMetadataBuilder21 declassificationExemption(final String declassificationExemption) {
         nitfDeclassificationExemption = declassificationExemption;
         return this;
     }
@@ -249,7 +272,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 downgrade(final String downgrade) {
+    public SecurityMetadataBuilder21 downgrade(final String downgrade) {
         nitfDowngrade = downgrade;
         return this;
     }
@@ -269,7 +292,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * string if downgrading does not apply.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 downgradeDate(final String downgradeDate) {
+    public SecurityMetadataBuilder21 downgradeDate(final String downgradeDate) {
         nitfDowngradeDate = downgradeDate;
         return this;
     }
@@ -292,7 +315,7 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * maximum), or an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 classificationText(final String classificationText) {
+    public SecurityMetadataBuilder21 classificationText(final String classificationText) {
         nitfClassificationText = classificationText;
         return this;
     }
@@ -314,13 +337,13 @@ public class SecurityMetadataBuilder21 extends SecurityMetadataBuilder<SecurityM
      * character), or an empty string.
      * @return this builder, to support method chaining
      */
-    public final SecurityMetadataBuilder21 classificationAuthorityType(final String classificationAuthorityType) {
+    public SecurityMetadataBuilder21 classificationAuthorityType(final String classificationAuthorityType) {
         nitfClassificationAuthorityType = classificationAuthorityType;
         return this;
     }
 
     @Override
-    final void populateVersionSpecific(final SecurityMetadataImpl securityMetadata) {
+    void populateVersionSpecific(final SecurityMetadataImpl securityMetadata) {
         securityMetadata.setFileType(nitfFileType);
         securityMetadata.setDowngrade(nitfDowngrade);
         securityMetadata.setSecuritySourceDate(nitfSecuritySourceDate);

--- a/core/src/test/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/security/impl/FileSecurityMetadataBuilderTest.java
@@ -34,7 +34,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder21() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -46,11 +46,11 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder21Copy() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        FileSecurityMetadataBuilder21 builderCopy = new FileSecurityMetadataBuilder21(securityMetadata);
+        FileSecurityMetadataBuilder21 builderCopy = FileSecurityMetadataBuilder21.newInstance(securityMetadata);
         FileSecurityMetadata securityMetadata2 = builderCopy.get();
         checkNitf21SecurityMetadataUnclasAndEmpty(securityMetadata2);
         assertEquals("00000", securityMetadata2.getFileCopyNumber());
@@ -59,7 +59,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder21CopyAll() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.RESTRICTED)
                 .fileCopyNumber("00001")
                 .securityClassificationSystem("AS")
@@ -80,7 +80,7 @@ public class FileSecurityMetadataBuilderTest {
                 .classificationAuthority("Some Person");
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        FileSecurityMetadataBuilder21 builderCopy = new FileSecurityMetadataBuilder21(securityMetadata);
+        FileSecurityMetadataBuilder21 builderCopy = FileSecurityMetadataBuilder21.newInstance(securityMetadata);
         FileSecurityMetadata securityMetadata2 = builderCopy.get();
         assertEquals(SecurityClassification.RESTRICTED, securityMetadata2.getSecurityClassification());
         assertEquals("AS", securityMetadata2.getSecurityClassificationSystem());
@@ -104,7 +104,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder20Copy() {
-        FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+        FileSecurityMetadataBuilder20 builder = FileSecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.RESTRICTED)
                 .fileCopyNumber("00001")
                 .codewords("AB CD")
@@ -117,7 +117,7 @@ public class FileSecurityMetadataBuilderTest {
                 .securityControlNumber("BOGUS");
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        FileSecurityMetadataBuilder20 builderCopy = new FileSecurityMetadataBuilder20(securityMetadata);
+        FileSecurityMetadataBuilder20 builderCopy = FileSecurityMetadataBuilder20.newInstance(securityMetadata);
         FileSecurityMetadata securityMetadata2 = builderCopy.get();
         assertEquals("AB CD", securityMetadata2.getCodewords());
         assertEquals("WITH CARE", securityMetadata2.getControlAndHandling());
@@ -152,7 +152,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderClassificationSystem() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .securityClassificationSystem("AS");
         FileSecurityMetadata securityMetadata = builder.get();
@@ -163,7 +163,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderCodewords() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .codewords("abc123");
         FileSecurityMetadata securityMetadata = builder.get();
@@ -173,7 +173,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderControlAndHandling() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .controlAndHandling("AZ,BY");
         FileSecurityMetadata securityMetadata = builder.get();
@@ -183,7 +183,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderReleaseInstructions() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .releaseInstructions("AS CA NZ");
         FileSecurityMetadata securityMetadata = builder.get();
@@ -193,7 +193,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDeclassificationDate() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("DD")
                 .declassificationDate("20201020");
@@ -205,7 +205,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDeclassificationExemption() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("X")
                 .declassificationExemption("X251");
@@ -217,7 +217,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDowngrade() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("GE")
                 .downgrade("R")
@@ -233,7 +233,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderClassificationAuthority() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .classificationAuthorityType("M")
                 .classificationAuthority("Derive-Multiple")
@@ -249,7 +249,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderControlNumber() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .securityControlNumber("Obfuscation");
         FileSecurityMetadata securityMetadata = builder.get();
@@ -259,7 +259,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderNSIF() {
-        FileSecurityMetadataBuilder21 builder = new FileSecurityMetadataBuilder21(FileType.NSIF_ONE_ZERO);
+        FileSecurityMetadataBuilder21 builder = FileSecurityMetadataBuilder21.newInstance(FileType.NSIF_ONE_ZERO);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -269,7 +269,7 @@ public class FileSecurityMetadataBuilderTest {
  
     @Test
     public void checkSecurityMetadataBuilder20() {
-        FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+        FileSecurityMetadataBuilder20 builder = FileSecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         FileSecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -281,7 +281,7 @@ public class FileSecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder20Downgrade() {
-        FileSecurityMetadataBuilder20 builder = new FileSecurityMetadataBuilder20();
+        FileSecurityMetadataBuilder20 builder = FileSecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.UNCLASSIFIED)
                 .downgradeDateOrSpecialCase("999998")
                 .downgradeEvent("When its good.")

--- a/core/src/test/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilderTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/security/impl/SecurityMetadataBuilderTest.java
@@ -34,7 +34,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder21() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -43,18 +43,18 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder21Copy() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        SecurityMetadataBuilder21 builderCopy = new SecurityMetadataBuilder21(securityMetadata);
+        SecurityMetadataBuilder21 builderCopy = SecurityMetadataBuilder21.newInstance(securityMetadata);
         SecurityMetadata securityMetadata2 = builderCopy.get();
         checkNitf21SecurityMetadataUnclasAndEmpty(securityMetadata2);
     }
 
     @Test
     public void checkSecurityMetadataBuilder21CopyAll() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE);
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE);
         builder.securityClassification(SecurityClassification.RESTRICTED)
                 .securityClassificationSystem("AS")
                 .downgrade("F")
@@ -73,7 +73,7 @@ public class SecurityMetadataBuilderTest {
                 .classificationAuthority("Some Person");
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        SecurityMetadataBuilder21 builderCopy = new SecurityMetadataBuilder21(securityMetadata);
+        SecurityMetadataBuilder21 builderCopy = SecurityMetadataBuilder21.newInstance(securityMetadata);
         SecurityMetadata securityMetadata2 = builderCopy.get();
         assertEquals(SecurityClassification.RESTRICTED, securityMetadata2.getSecurityClassification());
         assertEquals("AS", securityMetadata2.getSecurityClassificationSystem());
@@ -95,7 +95,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder20Copy() {
-        SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+        SecurityMetadataBuilder20 builder = SecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.RESTRICTED)
                 .codewords("AB CD")
                 .controlAndHandling("WITH CARE")
@@ -106,7 +106,7 @@ public class SecurityMetadataBuilderTest {
                 .securityControlNumber("BOGUS");
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
-        SecurityMetadataBuilder20 builderCopy = new SecurityMetadataBuilder20(securityMetadata);
+        SecurityMetadataBuilder20 builderCopy = SecurityMetadataBuilder20.newInstance(securityMetadata);
         SecurityMetadata securityMetadata2 = builderCopy.get();
         assertEquals("AB CD", securityMetadata2.getCodewords());
         assertEquals("WITH CARE", securityMetadata2.getControlAndHandling());
@@ -137,7 +137,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderClassificationSystem() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .securityClassificationSystem("AS");
         SecurityMetadata securityMetadata = builder.get();
@@ -148,7 +148,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderCodewords() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .codewords("abc123");
         SecurityMetadata securityMetadata = builder.get();
@@ -158,7 +158,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderControlAndHandling() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .controlAndHandling("AZ,BY");
         SecurityMetadata securityMetadata = builder.get();
@@ -168,7 +168,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderReleaseInstructions() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .releaseInstructions("AS CA NZ");
         SecurityMetadata securityMetadata = builder.get();
@@ -178,7 +178,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDeclassificationDate() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("DD")
                 .declassificationDate("20201020");
@@ -190,7 +190,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDeclassificationExemption() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("X")
                 .declassificationExemption("X251");
@@ -202,7 +202,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderDowngrade() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .declassificationType("GE")
                 .downgrade("R")
@@ -218,7 +218,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderClassificationAuthority() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .classificationAuthorityType("M")
                 .classificationAuthority("Derive-Multiple")
@@ -234,7 +234,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderControlNumber() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NITF_TWO_ONE)
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NITF_TWO_ONE)
                 .securityClassification(SecurityClassification.UNCLASSIFIED)
                 .securityControlNumber("Obfuscation");
         SecurityMetadata securityMetadata = builder.get();
@@ -244,7 +244,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilderNSIF() {
-        SecurityMetadataBuilder21 builder = new SecurityMetadataBuilder21(FileType.NSIF_ONE_ZERO);
+        SecurityMetadataBuilder21 builder = SecurityMetadataBuilder21.newInstance(FileType.NSIF_ONE_ZERO);
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -254,7 +254,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder20() {
-        SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+        SecurityMetadataBuilder20 builder = SecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.UNCLASSIFIED);
         SecurityMetadata securityMetadata = builder.get();
         assertNotNull(securityMetadata);
@@ -264,7 +264,7 @@ public class SecurityMetadataBuilderTest {
 
     @Test
     public void checkSecurityMetadataBuilder20Downgrade() {
-        SecurityMetadataBuilder20 builder = new SecurityMetadataBuilder20();
+        SecurityMetadataBuilder20 builder = SecurityMetadataBuilder20.newInstance();
         builder.securityClassification(SecurityClassification.UNCLASSIFIED)
                 .downgradeDateOrSpecialCase("999998")
                 .downgradeEvent("When its good.");


### PR DESCRIPTION
This follows on from the main IMG-233 changes to make builders for the security / file security metadata.