### PR TITLE
Fix for blank numbers

### DIFF
--- a/core/src/main/java/org/codice/imaging/nitf/core/common/impl/AbstractSegmentWriter.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/common/impl/AbstractSegmentWriter.java
@@ -140,7 +140,9 @@ public abstract class AbstractSegmentWriter {
     protected final void writeFixedLengthString(final String s, final int length)
             throws IOException {
         String toWrite;
-        if (s.length() > length) {
+        if (s == null) {
+            toWrite = padStringToLength("", length);
+        } else if (s.length() > length) {
             LOG.warn(String.format("Truncated string \"%s\", max length is %d", s, length));
             toWrite = s.substring(0, length);
         } else {

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
@@ -538,11 +538,15 @@ public class TreParser {
 
     private String getValidatedIntegerValue(final String value, final FieldType fieldType) throws NitfFormatException {
         String paddedValue;
-        if (value.length() > fieldType.getLength().intValue()) {
+        String trimmedValue = value.trim();
+        if (trimmedValue.length() > fieldType.getLength().intValue()) {
             throw new NitfFormatException("Incorrect length serialising out: " + fieldType.getName());
         }
         try {
-            int intValue = Integer.parseInt(value);
+            int intValue = 0;
+            if (trimmedValue.length() > 0) {
+                intValue = Integer.parseInt(trimmedValue);
+            }
             validateIntegerValueRange(intValue, fieldType);
             paddedValue = padIntegerToLength(intValue, fieldType.getLength().intValue());
         } catch (NumberFormatException ex) {

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/PIATGB_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/PIATGB_Test.java
@@ -49,4 +49,24 @@ public class PIATGB_Test extends SharedTreTest {
         assertEquals("-35.30812 ", piatgb.getFieldValue("TGTLAT"));
         assertEquals("+149.12447 ", piatgb.getFieldValue("TGTLON"));
     }
+
+    @Test
+    public void blankLatLongPIATGB() throws Exception {
+        String treTag = "PIATGB";
+        String testData = "PIATGB0011755HFA9359093610ABCDEFGHIJUVWXYAS702XX351655S1490742EWGECanberra Hill                                                 ";
+        int expectedLength = treTag.length() + "00117".length() + 117;
+
+        Tre piatgb = parseTRE(testData, expectedLength, treTag);
+        assertEquals(10, piatgb.getEntries().size());
+        assertEquals("55HFA9359093610", piatgb.getFieldValue("TGTUTM"));
+        assertEquals("ABCDEFGHIJUVWXY", piatgb.getFieldValue("PIATGAID"));
+        assertEquals("AS", piatgb.getFieldValue("PIACTRY"));
+        assertEquals("702XX", piatgb.getFieldValue("PIACAT"));
+        assertEquals("351655S1490742E", piatgb.getFieldValue("TGTGEO"));
+        assertEquals("WGE", piatgb.getFieldValue("DATUM"));
+        assertEquals("Canberra Hill                         ", piatgb.getFieldValue("TGTNAME"));
+        assertEquals("   ", piatgb.getFieldValue("PERCOVER"));
+        assertEquals("          ", piatgb.getFieldValue("TGTLAT"));
+        assertEquals("           ", piatgb.getFieldValue("TGTLON"));
+    }
 }


### PR DESCRIPTION
Allows the writing of blank or null integers and real numbers as spaces to support TREs that allow null numbers to represent unknown values such as the PIATGB TRE's TGTLAT and TGTLON fields.