### PR TITLE
IMG-250 Overloads file() and inputStream() methods of NitfParserInputFlow

### DIFF
--- a/fluent-api/src/main/java/org/codice/imaging/nitf/fluent/NitfParserInputFlow.java
+++ b/fluent-api/src/main/java/org/codice/imaging/nitf/fluent/NitfParserInputFlow.java
@@ -34,10 +34,30 @@ public interface NitfParserInputFlow {
     NitfParserParsingFlow file(File inputFile) throws FileNotFoundException;
 
     /**
+     * Begins a NITF parsing flow using a file as input.
+     *
+     * @param inputFile the NITF file to read from.
+     * @param skipTimeout - the timeout if reading from a slow input stream.
+     * @return a new NitfParserParsingFlow.
+     * @throws FileNotFoundException - when the file doesn't exist.
+     */
+    NitfParserParsingFlow file(File inputFile, long skipTimeout) throws FileNotFoundException;
+
+    /**
      * Begins a parsing flow using an InputStream as input.
      *
      * @param inputStream - the InputStream to read the NITF data from.
      * @return a new NitfParserParsingFlow.
      */
     NitfParserParsingFlow inputStream(InputStream inputStream);
+
+
+    /**
+     * Begins a parsing flow using an InputStream as input with a timeout.
+     *
+     * @param inputStream - the InputStream to read the NITF data from.
+     * @param skipTimeout - the timeout if reading from a slow input stream.
+     * @return a new NitfParserParsingFlow.
+     */
+    NitfParserParsingFlow inputStream(InputStream inputStream, long skipTimeout);
 }

--- a/fluent/src/main/java/org/codice/imaging/nitf/fluent/impl/NitfParserInputFlowImpl.java
+++ b/fluent/src/main/java/org/codice/imaging/nitf/fluent/impl/NitfParserInputFlowImpl.java
@@ -27,6 +27,7 @@ import org.codice.imaging.nitf.fluent.NitfParserParsingFlow;
  * NITF parser.
  */
 public class NitfParserInputFlowImpl implements NitfParserInputFlow {
+    private static final long DEFAULT_SKIP_TIMEOUT = 0;
 
     /**
      * Constructor.
@@ -41,8 +42,7 @@ public class NitfParserInputFlowImpl implements NitfParserInputFlow {
      */
     @Override
     public final NitfParserParsingFlow file(final File inputFile) throws FileNotFoundException {
-        NitfInputStreamReader nitfReader = new NitfInputStreamReader(new FileInputStream(inputFile));
-        return new NitfParserParsingFlowImpl(nitfReader);
+        return file(inputFile, DEFAULT_SKIP_TIMEOUT);
     }
 
     /**
@@ -63,8 +63,7 @@ public class NitfParserInputFlowImpl implements NitfParserInputFlow {
      */
     @Override
     public final NitfParserParsingFlow inputStream(final InputStream inputStream) {
-        NitfInputStreamReader nitfReader = new NitfInputStreamReader(inputStream);
-        return new NitfParserParsingFlowImpl(nitfReader);
+        return inputStream(inputStream, DEFAULT_SKIP_TIMEOUT);
     }
 
     /**

--- a/fluent/src/main/java/org/codice/imaging/nitf/fluent/impl/NitfParserInputFlowImpl.java
+++ b/fluent/src/main/java/org/codice/imaging/nitf/fluent/impl/NitfParserInputFlowImpl.java
@@ -50,8 +50,31 @@ public class NitfParserInputFlowImpl implements NitfParserInputFlow {
      * {@inheritDoc}
      */
     @Override
+    public final NitfParserParsingFlow file(final File inputFile, final long skipTimeout)
+        throws FileNotFoundException {
+        NitfInputStreamReader nitfReader = new NitfInputStreamReader(new FileInputStream(inputFile));
+        nitfReader.setSkipTimeout(skipTimeout);
+        return new NitfParserParsingFlowImpl(nitfReader);
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
     public final NitfParserParsingFlow inputStream(final InputStream inputStream) {
         NitfInputStreamReader nitfReader = new NitfInputStreamReader(inputStream);
+        return new NitfParserParsingFlowImpl(nitfReader);
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public final NitfParserParsingFlow inputStream(final InputStream inputStream, final long skipTimeout) {
+        NitfInputStreamReader nitfReader = new NitfInputStreamReader(inputStream);
+        nitfReader.setSkipTimeout(skipTimeout);
         return new NitfParserParsingFlowImpl(nitfReader);
     }
 }


### PR DESCRIPTION
This allows for the skip timeout to be configured by clients.

Relates to #193 