### PR TITLE
Upgrade to Java 11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,11 +43,10 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${jaxb.api.version}</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jakarta.xml.bind.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
@@ -56,8 +55,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.activation</groupId>
-            <artifactId>jakarta.activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <version>${jakarta.activation.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,15 @@
         <checkstyleplugin.version>2.17</checkstyleplugin.version>
         <spotbugs.version>4.2.1</spotbugs.version>
         <spotbugs.mavenplugin.version>3.1.12</spotbugs.mavenplugin.version>
-        <mavencompilerplugin.version>3.3</mavencompilerplugin.version>
+        <mavencompilerplugin.version>3.8.1</mavencompilerplugin.version>
         <mavenremoteresources.version>1.5</mavenremoteresources.version>
         <mavenjavadocplugin.version>2.9.1</mavenjavadocplugin.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
         <jaxbmavenplugin.version>2.4</jaxbmavenplugin.version>
-        <jakarta.activation.version>1.2.1</jakarta.activation.version>
+        <jakarta.activation.version>1.2.2</jakarta.activation.version>
+        <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
         <jaxb.api.version>2.3.0</jaxb.api.version>
     </properties>
 


### PR DESCRIPTION
Upgrade to compile with Java 11
- Needed to include Jakarta XML bind and jakarta activation api
- Updated the maven compiler plugin (wasn't required but was overdue)
- Verified and tested with the Alliance Java 11 branch downstream https://github.com/codice/alliance/tree/alliance-java11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codice/imaging-nitf/218)
<!-- Reviewable:end -->
