### PR TITLE
Upgrade to jakarta.xml.bind 4.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,8 +152,8 @@
                         <version>${glassfish.jaxb.version}</version>
                     </dependency>
                     <dependency>
-                        <groupId>com.sun.activation</groupId>
-                        <artifactId>jakarta.activation</artifactId>
+                        <groupId>jakarta.activation</groupId>
+                        <artifactId>jakarta.activation-api</artifactId>
                         <version>${jakarta.activation.version}</version>
                     </dependency>
                 </dependencies>

--- a/core/src/main/java/org/codice/imaging/nitf/core/image/impl/RasterProductFormatUtilities.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/image/impl/RasterProductFormatUtilities.java
@@ -14,11 +14,11 @@
  */
 package org.codice.imaging.nitf.core.image.impl;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.schema.Rpfs;
 import org.slf4j.Logger;

--- a/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
+++ b/core/src/main/java/org/codice/imaging/nitf/core/tre/impl/TreParser.java
@@ -27,10 +27,11 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/BANDSB_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/BANDSB_Test.java
@@ -16,10 +16,10 @@ package org.codice.imaging.nitf.core.tre.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.junit.Test;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/CCINFA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/CCINFA_Test.java
@@ -14,12 +14,12 @@
  */
 package org.codice.imaging.nitf.core.tre.impl;
 
+import jakarta.xml.bind.DatatypeConverter;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import javax.xml.bind.DatatypeConverter;
 import org.codice.imaging.nitf.core.common.NitfReader;
 import org.codice.imaging.nitf.core.common.impl.NitfInputStreamReader;
 import org.codice.imaging.nitf.core.tre.Tre;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/ENGRDA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/ENGRDA_Test.java
@@ -14,12 +14,12 @@
  */
 package org.codice.imaging.nitf.core.tre.impl;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import org.codice.imaging.nitf.core.impl.SlottedParseStrategy;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.common.impl.NitfInputStreamReader;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/MTIMSA_Test.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/MTIMSA_Test.java
@@ -16,10 +16,10 @@ package org.codice.imaging.nitf.core.tre.impl;
 
 import static org.junit.Assert.assertEquals;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
 import org.codice.imaging.nitf.core.tre.TreGroup;

--- a/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/TreTortureTest.java
+++ b/core/src/test/java/org/codice/imaging/nitf/core/tre/impl/TreTortureTest.java
@@ -14,6 +14,7 @@
  */
 package org.codice.imaging.nitf.core.tre.impl;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -22,7 +23,6 @@ import java.io.StringReader;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import org.codice.imaging.nitf.core.common.NitfFormatException;

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,10 @@
         <mavenjavadocplugin.version>2.9.1</mavenjavadocplugin.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
-        <jaxbmavenplugin.version>2.4</jaxbmavenplugin.version>
-        <jakarta.activation.version>1.2.2</jakarta.activation.version>
-        <jakarta.xml.bind.version>2.3.2</jakarta.xml.bind.version>
+        <glassfish.jaxb.version>4.0.2</glassfish.jaxb.version>
+        <jaxbmavenplugin.version>3.1.0</jaxbmavenplugin.version>
+        <jakarta.activation.version>2.1.1</jakarta.activation.version>
+        <jakarta.xml.bind.version>4.0.0</jakarta.xml.bind.version>
         <jaxb.api.version>2.3.0</jaxb.api.version>
         <commons-io.version>2.11.0</commons-io.version>
     </properties>

--- a/render/src/test/java/org/codice/imaging/nitf/render/Jpeg2000Test.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/Jpeg2000Test.java
@@ -18,7 +18,7 @@
  */
 package org.codice.imaging.nitf.render;
 
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;

--- a/render/src/test/java/org/codice/imaging/nitf/render/JpegTest.java
+++ b/render/src/test/java/org/codice/imaging/nitf/render/JpegTest.java
@@ -18,6 +18,7 @@
  */
 package org.codice.imaging.nitf.render;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -28,7 +29,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import org.codice.imaging.nitf.core.image.ImageCompression;
 import org.codice.imaging.nitf.core.image.ImageSegment;
 import org.junit.Test;

--- a/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
+++ b/trewrap/src/test/java/org/codice/imaging/nitf/trewrap/MTIMSA_WrapTest.java
@@ -14,6 +14,7 @@
  */
 package org.codice.imaging.nitf.trewrap;
 
+import static jakarta.xml.bind.DatatypeConverter.parseHexBinary;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -21,7 +22,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import static javax.xml.bind.DatatypeConverter.parseHexBinary;
 import org.codice.imaging.nitf.core.common.NitfFormatException;
 import org.codice.imaging.nitf.core.tre.Tre;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
The package `javax.xml.bind` has been replaced with `jakarta.xml.bind` in projects like Spring. This commit updates the dependencies to use the new Jakarta packages.